### PR TITLE
Fix bug in copy() for state vectors.

### DIFF
--- a/src/states.jl
+++ b/src/states.jl
@@ -49,7 +49,7 @@ Ket(b::Basis) = Ket(b, zeros(Complex128, length(b)))
 
 Base.length(a::StateVector) = length(a.basis)::Int
 bases.basis(a::StateVector) = a.basis
-Base.copy{T}(a::T) = T(a.basis, copy(a.data))
+Base.copy{T<:StateVector}(a::T) = T(a.basis, copy(a.data))
 
 # Arithmetic operations
 *(a::Bra, b::Ket) = (check_multiplicable(a, b); sum(a.data.*b.data))


### PR DESCRIPTION
Missing parameter constraint means it was implemented for all types.