### PR TITLE
Change interface of mcwf to match that of master

### DIFF
--- a/src/mcwf.jl
+++ b/src/mcwf.jl
@@ -220,7 +220,7 @@ slightly faster.
 * `J`: Vector containing all jump operators which can be of any arbitrary
         operator type.
 * `seed=rand()`: Seed used for the random number generator.
-* `rates=ones()`: Vector or matrix of decay rates.
+* `rates=ones()`: Vector of decay rates.
 * `fout`: If given, this function `fout(t, psi)` is called every time an
         output should be displayed. ATTENTION: The state `psi` is neither
         normalized nor permanent! It is still in use by the ode solve

--- a/src/mcwf.jl
+++ b/src/mcwf.jl
@@ -97,18 +97,18 @@ end
 
 function jump(rng, t::Float64, psi::Ket, J::Vector, psi_new::Ket, rates::Vector{Float64})
     if length(J)==1
-        operators.gemv!(sqrt(rates[1]), J[1], psi, complex(0.), psi_new)
+        operators.gemv!(complex(sqrt(rates[1])), J[1], psi, complex(0.), psi_new)
         psi_new.data ./= norm(psi_new)
     else
         probs = zeros(Float64, length(J))
         for i=1:length(J)
-            operators.gemv!(sqrt(rates[i]), J[i], psi, complex(0.), psi_new)
+            operators.gemv!(complex(sqrt(rates[i])), J[i], psi, complex(0.), psi_new)
             probs[i] = dot(psi_new.data, psi_new.data)
         end
         cumprobs = cumsum(probs./sum(probs))
         r = rand(rng)
         i = findfirst(cumprobs.>r)
-        operators.gemv!(sqrt(rates[i]/probs[i]), J[i], psi, complex(0.), psi_new)
+        operators.gemv!(complex(sqrt(rates[i]/probs[i])), J[i], psi, complex(0.), psi_new)
     end
     return nothing
 end
@@ -133,7 +133,7 @@ function dmcwf_h(psi::Ket, H::Operator,
                  J::Vector, Jdagger::Vector, dpsi::Ket, tmp::Ket, rates::Vector{Float64})
     operators.gemv!(complex(0,-1.), H, psi, complex(0.), dpsi)
     for i=1:length(J)
-        operators.gemv!(rates[i], J[i], psi, complex(0.), tmp)
+        operators.gemv!(complex(rates[i]), J[i], psi, complex(0.), tmp)
         operators.gemv!(-complex(0.5,0.), Jdagger[i], tmp, complex(1.), dpsi)
     end
     return dpsi

--- a/test/test_timeevolution_mcwf.jl
+++ b/test/test_timeevolution_mcwf.jl
@@ -131,17 +131,21 @@ tout_master, ρt_master = timeevolution.master(T, ρ₀, Hdense, J1_dense)
 
 ρ_average_1 = DenseOperator[0 * ρ₀ for i=1:length(T)]
 ρ_average_2 = DenseOperator[0 * ρ₀ for i=1:length(T)]
+ρ_average_3 = DenseOperator[0 * ρ₀ for i=1:length(T)]
 for i=1:Ntrajectories
     tout, Ψt_1 = timeevolution.mcwf(T, Ψ₀, Hdense, J1_dense; seed=UInt(i))
     tout, Ψt_2 = timeevolution.mcwf(T, Ψ₀, Hdense, J2_dense; seed=UInt(i))
+    tout, Ψt_3 = timeevolution.mcwf(T, Ψ₀, Hdense, [J1_dense[1]/sqrt(γ)]; seed=UInt(i), rates=[γ])
     for j=1:length(T)
         ρ_average_1[j] += (Ψt_1[j] ⊗ dagger(Ψt_1[j]))/Ntrajectories
         ρ_average_2[j] += (Ψt_2[j] ⊗ dagger(Ψt_2[j]))/Ntrajectories
+        ρ_average_3[j] += (Ψt_3[j] ⊗ dagger(Ψt_3[j]))/Ntrajectories
     end
 end
 for i=1:length(T)
     @test tracedistance(ρt_master[i], ρ_average_1[i]) < 0.1
     @test tracedistance(ρt_master[i], ρ_average_2[i]) < 0.1
+    @test tracedistance(ρt_master[i], ρ_average_3[i]) < 0.1
 end
 
 

--- a/test/test_timeevolution_mcwf.jl
+++ b/test/test_timeevolution_mcwf.jl
@@ -30,12 +30,14 @@ Hc = embed(basis, 2, ωc*number(fockbasis))
 Hint = sm ⊗ create(fockbasis) + sp ⊗ destroy(fockbasis)
 H = Ha + Hc + Hint
 Hdense = full(H)
+Hlazy = LazySum(Ha, Hc, Hint)
 
 # Jump operators
 Ja = embed(basis, 1, sqrt(γ)*sm)
 Jc = embed(basis, 2, sqrt(κ)*destroy(fockbasis))
 J = [Ja, Jc]
 Jdense = map(full, J)
+Jlazy = [LazyTensor(basis, 1, sqrt(γ)*sm), LazyTensor(basis, 2, sqrt(κ)*destroy(fockbasis))]
 
 # Initial conditions
 Ψ₀ = spinup(spinbasis) ⊗ fockstate(fockbasis, 5)
@@ -63,6 +65,13 @@ end
 timeevolution.mcwf(T, Ψ₀, H, J; seed=UInt(2), reltol=1e-6, fout=fout)
 @test tout == t_fout && Ψt == Ψ_fout
 
+
+# Test mcwf for irreducible input
+tout, Ψt = timeevolution.mcwf(T, Ψ₀, Hlazy, J; seed=UInt(1), reltol=1e-6)
+@test norm(Ψt[end] - Ψ) < 1e-5
+
+tout, Ψt = timeevolution.mcwf(T, Ψ₀, H, Jlazy; seed=UInt(1), reltol=1e-6)
+@test norm(Ψt[end] - Ψ) < 1e-5
 
 # Test mcwf_h
 tout, Ψt = timeevolution.mcwf_h(T, Ψ₀, H, J; seed=UInt(1), reltol=1e-6)

--- a/test/test_timeevolution_mcwf.jl
+++ b/test/test_timeevolution_mcwf.jl
@@ -73,6 +73,9 @@ tout, Ψt = timeevolution.mcwf(T, Ψ₀, Hlazy, J; seed=UInt(1), reltol=1e-6)
 tout, Ψt = timeevolution.mcwf(T, Ψ₀, H, Jlazy; seed=UInt(1), reltol=1e-6)
 @test norm(Ψt[end] - Ψ) < 1e-5
 
+tout, Ψt = timeevolution.mcwf(T, Ψ₀, H, Jlazy./[sqrt(γ), sqrt(κ)]; seed=UInt(1), rates=[γ, κ], reltol=1e-6)
+@test norm(Ψt[end] - Ψ) < 1e-5
+
 # Test mcwf_h
 tout, Ψt = timeevolution.mcwf_h(T, Ψ₀, H, J; seed=UInt(1), reltol=1e-6)
 @test norm(Ψt[end]-Ψ) < 1e-5


### PR DESCRIPTION
I have changed the syntax of `timeevolution.mcwf` to accept the kwarg `rates` as in `timeevolution.master`.

It now accepts `rates` as a vector of floats of the same length as `J`. I also thought about implementing an internal diagonalization, such that if `rates` is a matrix, a new set of jump operators and rates is calculated using `diagonljumps`. However, since usually one computes many trajectories using the MCWF method, this would be expensive as the calculation is repeated for every trajectory. Instead, `timeevolution.mcwf` now throws an error if `rates` is a matrix, which points the user towards using `diagonaljumps` a priori.

The same changes were made to `mcwf_h`, but not `mcwf_nh`. I don't see why anyone would use `mcwf_nh` instead of `mcwf` if the rates are not already included in the Hamiltonian. Should we add this?

Please review @bastikr.