### PR TITLE
Remove part of definition of spectrum in docstrings

### DIFF
--- a/src/timecorrelations.jl
+++ b/src/timecorrelations.jl
@@ -72,8 +72,7 @@ Calculate spectrum as Fourier transform of a correlation function
 This is done with the Wiener-Khinchin theorem
 
 ```math
-S(ω, t) = \\int_{-∞}^{∞} dτ e^{-iωτ}⟨A^†(t+τ) A(t)⟩ =
-    2\\Re\\left\\{\\int_0^{∞} dτ e^{-iωτ}⟨A^†(t+τ)A(t)⟩\\right\\}
+S(ω, t) = 2\\Re\\left\\{\\int_0^{∞} dτ e^{-iωτ}⟨A^†(t+τ)A(t)⟩\\right\\}
 ```
 
 The argument `omega_samplepoints` gives the list of frequencies where ``S(ω)``


### PR DESCRIPTION
When doing some analytics, I realized that the relation we used to write the spectrum as the real part of the integral does not hold, in general, for quantized fields. The common approach seems to be to write the spectrum as real part using the classical counter-part and then replace the fields by operators (see, for example, _Mathematical Methods of Quantum Optics, R.R. Puri_). I think it would be best to only ever mention the definition of the spectrum with the real part.