### PR TITLE
Equate ⊗ with `tensor`

### DIFF
--- a/src/bases.jl
+++ b/src/bases.jl
@@ -126,7 +126,7 @@ function tensor(b1::Basis, b2::CompositeBasis)
     CompositeBasis(shape, bases)
 end
 tensor(bases::Basis...) = reduce(tensor, bases)
-⊗(a, b) = tensor(a, b)
+⊗ = tensor
 
 function ^(b::Basis, N::Int)
     if N < 1

--- a/test/test_bases.jl
+++ b/test/test_bases.jl
@@ -19,8 +19,10 @@ b3 = GenericBasis(shape3)
 
 @test tensor(b1) == b1
 comp_b1 = tensor(b1, b2)
+comp_uni = b1 ⊗ b2
 comp_b2 = tensor(b1, b1, b2)
 @test comp_b1.shape == [prod(shape1), prod(shape2)]
+@test comp_uni.shape == [prod(shape1), prod(shape2)]
 @test comp_b2.shape == [prod(shape1), prod(shape1), prod(shape2)]
 
 @test b1^3 == CompositeBasis(b1, b1, b1)


### PR DESCRIPTION
This way they are the same object (as intended I think?) and they share the same documentation string.