### PR TITLE
Change internals to Diffeq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - osx
     - linux
 julia:
-    - 0.5
     - 0.6
     - nightly
 matrix:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ More information, documentation and examples can be found on our website http://
 ### Development status
 
 **Latest release:**
-  * [![Status of latest release on julia 0.4][pkg-0.4-img]][pkg-0.4-url]
-  * [![Status of latest release on julia 0.5][pkg-0.5-img]][pkg-0.5-url]
   * [![Status of latest release on julia 0.6][pkg-0.6-img]][pkg-0.6-url]
 
 **Master branch:**
@@ -54,12 +52,6 @@ Additionally, you can contact us on Gitter: [![Chat on Gitter][gitter-img]][gitt
 
 [codecov-url]: https://codecov.io/gh/qojulia/QuantumOptics.jl
 [codecov-img]: https://codecov.io/gh/qojulia/QuantumOptics.jl/branch/master/graph/badge.svg
-
-[pkg-0.4-url]: http://pkg.julialang.org/?pkg=QuantumOptics&ver=0.4
-[pkg-0.4-img]: http://pkg.julialang.org/badges/QuantumOptics_0.4.svg
-
-[pkg-0.5-url]: http://pkg.julialang.org/?pkg=QuantumOptics&ver=0.5
-[pkg-0.5-img]: http://pkg.julialang.org/badges/QuantumOptics_0.5.svg
 
 [pkg-0.6-url]: http://pkg.julialang.org/?pkg=QuantumOptics&ver=0.6
 [pkg-0.6-img]: http://pkg.julialang.org/badges/QuantumOptics_0.6.svg

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.6
 Compat 0.17
 Roots
 OrdinaryDiffEq 2.34.0
-DiffEqCallbacks 0.7.0
+DiffEqCallbacks 0.7.1

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 Compat 0.17
 Roots
 OrdinaryDiffEq 2.34.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,5 @@
 julia 0.5
 Compat 0.17
 Roots
+OrdinaryDiffEq 2.34.0
+DiffEqCallbacks 0.7.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -41,8 +41,6 @@ function master(H::Operator, J::Vector;
                         fout=fout,
                         steady_state = true,
                         eps = eps, kwargs...)
-    timeevolution.recast!(u[end],rho0)
-    rho0
 end
 
 """

--- a/src/timecorrelations.jl
+++ b/src/timecorrelations.jl
@@ -36,13 +36,12 @@ function correlation(tspan::Vector{Float64}, rho0::DenseOperator, H::Operator, J
                      rates::Union{Vector{Float64}, Matrix{Float64}, Void}=nothing,
                      Jdagger::Vector=dagger.(J),
                      kwargs...)
-    exp_values = Complex128[]
     function fout(t, rho)
-        push!(exp_values, expect(op1, rho))
+        expect(op1, rho)
     end
-    timeevolution.master(tspan, op2*rho0, H, J; rates=rates, Jdagger=Jdagger,
+    t,u = timeevolution.master(tspan, op2*rho0, H, J; rates=rates, Jdagger=Jdagger,
                         fout=fout, kwargs...)
-    return exp_values
+    u
 end
 
 function correlation(rho0::DenseOperator, H::Operator, J::Vector,
@@ -52,15 +51,12 @@ function correlation(rho0::DenseOperator, H::Operator, J::Vector,
                      Jdagger::Vector=dagger.(J),
                      kwargs...)
     op2rho0 = op2*rho0
-    tout = Float64[0.]
-    exp_values = Complex128[expect(op1, op2rho0)]
+    exp1 = expect(op1, op2rho0)
     function fout(t, rho)
-        push!(tout, t)
-        push!(exp_values, expect(op1, rho))
+        expect(op1, rho)
     end
-    steadystate.master(H, J; rho0=op2rho0, eps=eps, h0=h0, fout=fout,
-                       rates=rates, Jdagger=Jdagger, kwargs...)
-    return tout, exp_values
+    t,u = steadystate.master(H, J; rho0=op2rho0, eps=eps, h0=h0, fout=fout,
+                       rates=rates, Jdagger=Jdagger, save_everystep=true,kwargs...)
 end
 
 
@@ -115,7 +111,7 @@ end
 function spectrum(H::Operator, J::Vector, op::Operator;
                 rho0::DenseOperator=tensor(basisstate(H.basis_l, 1), dagger(basisstate(H.basis_r, 1))),
                 eps::Float64=1e-4, h0=10.,
-                rho_ss::DenseOperator=steadystate.master(H, J; eps=eps),
+                rho_ss::DenseOperator=steadystate.master(H, J; eps=eps)[end][end],
                 kwargs...)
     tspan, exp_values = correlation(rho_ss, H, J, dagger(op), op, eps=eps, h0=h0, kwargs...)
     dtmin = minimum(diff(tspan))

--- a/src/timeevolution_base.jl
+++ b/src/timeevolution_base.jl
@@ -1,4 +1,4 @@
-using ..ode_dopri
+using ..ode_dopri, ..metrics
 
 import OrdinaryDiffEq, DiffEqCallbacks
 
@@ -8,7 +8,8 @@ function recast! end
 df(t, state::T, dstate::T)
 """
 function integrate{T}(tspan::Vector{Float64}, df::Function, x0::Vector{Complex128},
-            state::T, dstate::T, fout::Function; callback = nothing, kwargs...)
+            state::T, dstate::T, fout::Function;
+            steady_state = false, eps = 1e-3, kwargs...)
 
     function df_(t, x::Vector{Complex128}, dx::Vector{Complex128})
         recast!(x, state)
@@ -24,24 +25,38 @@ function integrate{T}(tspan::Vector{Float64}, df::Function, x0::Vector{Complex12
     # TODO: Infer the output of `fout` instead of computing it
     recast!(x0, state)
     out = DiffEqCallbacks.SavedValues(Float64,typeof(fout(tspan[1], state)))
+    scb = DiffEqCallbacks.SavingCallback(fout_,out,saveat=tspan)
 
     # Build callback solve with DP5
     # TODO: Expose algorithm choice
-    cb = DiffEqCallbacks.SavingCallback(fout_,out,saveat=tspan)
 
-    if callback == nothing
-        _cb = cb
+    prob = OrdinaryDiffEq.ODEProblem{true}(df_, x0,(tspan[1],tspan[end]))
+
+    if steady_state
+        _cb = OrdinaryDiffEq.DiscreteCallback(
+                                SteadyStateCondtion(copy(state),eps,state),
+                                (integrator)->OrdinaryDiffEq.terminate!(integrator),
+                                save_positions = (false,false))
+        cb = OrdinaryDiffEq.CallbackSet(_cb,scb)
+        sol = OrdinaryDiffEq.solve(
+                    prob,
+                    OrdinaryDiffEq.DP5();
+                    reltol = 1.0e-6,
+                    abstol = 1.0e-8,
+                    save_everystep = false, save_start = false,
+                    callback=cb, kwargs...)
+        # TODO: On v0.7 it's type-stable to return only sol.u[end]!
+        return sol.t,sol.u
     else
-        _cb = OrdinaryDiffEq.CallbackSet(cb,callback)
+        sol = OrdinaryDiffEq.solve(
+                    prob,
+                    OrdinaryDiffEq.DP5();
+                    reltol = 1.0e-6,
+                    abstol = 1.0e-8,
+                    save_everystep = false, save_start = false, save_end = false,
+                    callback=scb, kwargs...)
+        return out.t,out.saveval
     end
-    sol = OrdinaryDiffEq.solve(
-                OrdinaryDiffEq.ODEProblem{true}(df_, x0,(tspan[1],tspan[end])),
-                OrdinaryDiffEq.DP5();
-                reltol = 1.0e-6,
-                abstol = 1.0e-8,
-                save_everystep = false, save_start = false, save_end = false,
-                callback=_cb, kwargs...)
-    out.t,out.saveval
 end
 
 function integrate{T}(tspan::Vector{Float64}, df::Function, x0::Vector{Complex128},
@@ -50,4 +65,17 @@ function integrate{T}(tspan::Vector{Float64}, df::Function, x0::Vector{Complex12
         copy(state)
     end
     integrate(tspan, df, x0, state, dstate, fout; kwargs...)
+end
+
+struct SteadyStateCondtion{T,T2,T3}
+    rho0::T
+    eps::T2
+    state::T3
+end
+function (c::SteadyStateCondtion)(t,rho,integrator)
+    timeevolution.recast!(rho,c.state)
+    dt = integrator.dt
+    drho = metrics.tracedistance(c.rho0, c.state)
+    c.rho0.data[:] = c.state.data
+    drho/dt < c.eps
 end

--- a/src/timeevolution_base.jl
+++ b/src/timeevolution_base.jl
@@ -8,10 +8,10 @@ function recast! end
 df(t, state::T, dstate::T)
 """
 function integrate{T}(tspan::Vector{Float64}, df::Function, x0::Vector{Complex128},
-            state::T, dstate::T, fout::Function,
-            alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm = OrdinaryDiffEq.DP5();
+            state::T, dstate::T, fout::Function;
+            alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm = OrdinaryDiffEq.DP5(),
             steady_state = false, eps = 1e-3, save_everystep = false,
-            kwargs...)
+            callback = nothing, kwargs...)
 
     function df_(t, x::Vector{Complex128}, dx::Vector{Complex128})
         recast!(x, state)
@@ -51,6 +51,8 @@ function integrate{T}(tspan::Vector{Float64}, df::Function, x0::Vector{Complex12
         cb = scb
     end
 
+    full_cb = OrdinaryDiffEq.CallbackSet(callback,cb)
+
     # TODO: Expose algorithm choice
     sol = OrdinaryDiffEq.solve(
                 prob,
@@ -59,12 +61,12 @@ function integrate{T}(tspan::Vector{Float64}, df::Function, x0::Vector{Complex12
                 abstol = 1.0e-8,
                 save_everystep = false, save_start = false,
                 save_end = false,
-                callback=cb, kwargs...)
+                callback=full_cb, kwargs...)
     out.t,out.saveval
 end
 
 function integrate{T}(tspan::Vector{Float64}, df::Function, x0::Vector{Complex128},
-            state::T, dstate::T, ::Void, args...; kwargs...)
+            state::T, dstate::T, ::Void; kwargs...)
     function fout(t::Float64, state::T)
         copy(state)
     end

--- a/src/timeevolution_base.jl
+++ b/src/timeevolution_base.jl
@@ -28,7 +28,7 @@ function integrate{T}(tspan::Vector{Float64}, df::Function, x0::Vector{Complex12
     # TODO: Expose algorithm choice
     cb = DiffEqCallbacks.SavingCallback(fout_,out,saveat=tspan)
     sol = OrdinaryDiffEq.solve(
-                OrdinaryDiffEq.ODEProblem(df_, x0,(tspan[1],tspan[end])),
+                OrdinaryDiffEq.ODEProblem{true}(df_, x0,(tspan[1],tspan[end])),
                 OrdinaryDiffEq.DP5();
                 reltol = 1.0e-6,
                 abstol = 1.0e-8,

--- a/src/timeevolution_base.jl
+++ b/src/timeevolution_base.jl
@@ -8,7 +8,8 @@ function recast! end
 df(t, state::T, dstate::T)
 """
 function integrate{T}(tspan::Vector{Float64}, df::Function, x0::Vector{Complex128},
-            state::T, dstate::T, fout::Function; kwargs...)
+            state::T, dstate::T, fout::Function; callback = nothing, kwargs...)
+
     function df_(t, x::Vector{Complex128}, dx::Vector{Complex128})
         recast!(x, state)
         recast!(dx, dstate)
@@ -27,13 +28,19 @@ function integrate{T}(tspan::Vector{Float64}, df::Function, x0::Vector{Complex12
     # Build callback solve with DP5
     # TODO: Expose algorithm choice
     cb = DiffEqCallbacks.SavingCallback(fout_,out,saveat=tspan)
+
+    if callback == nothing
+        _cb = cb
+    else
+        _cb = OrdinaryDiffEq.CallbackSet(cb,callback)
+    end
     sol = OrdinaryDiffEq.solve(
                 OrdinaryDiffEq.ODEProblem{true}(df_, x0,(tspan[1],tspan[end])),
                 OrdinaryDiffEq.DP5();
                 reltol = 1.0e-6,
                 abstol = 1.0e-8,
                 save_everystep = false, save_start = false, save_end = false,
-                callback=cb, kwargs...)
+                callback=_cb, kwargs...)
     out.t,out.saveval
 end
 

--- a/test/test_steadystate.jl
+++ b/test/test_steadystate.jl
@@ -75,6 +75,6 @@ nss = expect(create(fockbasis)*destroy(fockbasis), ρss)
 function fout_wrong(t, x)
   @assert x == t
 end
-@test_throws AssertionError steadystate.master(Hdense, Jdense; fout=fout_wrong)
+@test_throws MethodError steadystate.master(Hdense, Jdense; fout=fout_wrong)
 
 end # testset

--- a/test/test_steadystate.jl
+++ b/test/test_steadystate.jl
@@ -42,8 +42,8 @@ Jdense = map(full, J)
 
 tout, ρt = timeevolution.master([0,100], ρ₀, Hdense, Jdense; reltol=1e-7)
 
-ρss = steadystate.master(Hdense, Jdense; eps=1e-4)
-@test tracedistance(ρss, ρt[end]) < 1e-3
+tss, ρss = steadystate.master(Hdense, Jdense; eps=1e-4)
+@test tracedistance(ρss[end], ρt[end]) < 1e-3
 
 ρss = steadystate.eigenvector(Hdense, Jdense)
 @test tracedistance(ρss, ρt[end]) < 1e-6
@@ -57,8 +57,8 @@ Hp = η*(destroy(fockbasis) + create(fockbasis))
 Jp = [sqrt(2κ)*destroy(fockbasis)]
 n_an = η^2/κ^2
 
-ρss = steadystate.master(Hp, Jp; rho0=ρ0_p, eps=1e-4)
-nss = expect(create(fockbasis)*destroy(fockbasis), ρss)
+tss,ρss = steadystate.master(Hp, Jp; rho0=ρ0_p, eps=1e-4)
+nss = expect(create(fockbasis)*destroy(fockbasis), ρss[end])
 @test n_an - real(nss) < 1e-3
 
 ρss = steadystate.eigenvector(Hp, Jp)

--- a/test/test_timeevolution_schroedinger.jl
+++ b/test/test_timeevolution_schroedinger.jl
@@ -61,13 +61,10 @@ for (i, t) in enumerate(tout)
     @test tracedistance(rho_rot, full(R)*rho*dagger(full(R))) < 1e-5
 end
 
-t_fout = Float64[]
-psi_fout = []
 function fout(t, psi)
-  push!(t_fout, t)
-  push!(psi_fout, deepcopy(psi))
+ deepcopy(psi)
 end
-timeevolution.schroedinger(T, psi0, Hrot; fout=fout)
+t_fout, psi_fout = timeevolution.schroedinger(T, psi0, Hrot; fout=fout)
 @test t_fout == tout && psi_fout == psi_rot_t
 
 end # testset


### PR DESCRIPTION
This sets up the internals to use DiffEq. All of the tests pass. There is a breaking change in that the steady state parts now return the solution array (with saveat matching the giving timespan, so it's the same but includes the initial point). Other than that, nothing changes. This requires DiffEqCallbacks v0.7.0 which should be released shortly.

As for speed, benchmarks show that as setup it's roughly the same on very non-stiff problems. The previous integrator's `reltol=1e-7` takes as much steps as this one's `reltol=1e-6`, and with these the DiffEq one is ever so slightly faster. But true benchmarks should take into account error as well. The QO benchmarks should be run again like in https://github.com/qojulia/QuantumOptics.jl/issues/92 . Note that the current DiffEq infrusturcture takes a hit on very cheap problems due to Julia's keyword argument handling and lack of constant propogation, but those are both fixed in v0.7 so we'll get a free speedup when the next version of Julia is released.

But, the DiffEq DP5 uses PI adaptive time stepping which will be more stable and by far more efficient on semi-stiff equations.  And that's mostly the point. I wouldn't expect anything major on simple non-stiff equations like in the tests, but if you increase the stiffness of the PDE, then DiffEq allows a lot more options to handle stiff equations (whereas explicit Runge-Kutta methods simply fail). However, the option to pass integration algorithms to override the internal default is not part of this PR (but it would be very simple). Also, by changing `ODEProblem` to things like `DDEProblem` or `SDEProblem` this (with different algorithm choices) will solve other types of differential equations as proposed in https://github.com/qojulia/QuantumOptics.jl/issues/164 .