### PR TITLE
Generalization of FFTOperator to composite bases

### DIFF
--- a/src/particle.jl
+++ b/src/particle.jl
@@ -299,16 +299,25 @@ function transform(basis_l::PositionBasis, basis_r::MomentumBasis; ket_only::Boo
     end
 end
 
-function transform(basis_l::CompositeBasis, basis_r::CompositeBasis; ket_only::Bool=false)
+function transform(basis_l::CompositeBasis, basis_r::CompositeBasis; ket_only::Bool=false, index::Vector{Int}=Int[])
     @assert length(basis_l.bases) == length(basis_r.bases)
-    check_pos = typeof.(basis_l.bases) .== PositionBasis
-    check_mom = typeof.(basis_l.bases) .== MomentumBasis
-    if any(check_pos) && !any(check_mom)
-        @assert all(typeof.(basis_r.bases[check_pos]) .== MomentumBasis)
-        transform_xp(basis_l, basis_r, [1:length(basis_l.bases);][check_pos]; ket_only=ket_only)
-    elseif any(check_mom) && !any(check_pos)
-        @assert all(typeof.(basis_r.bases[check_pos]) .== PositionBasis)
-        transform_px(basis_l, basis_r, [1:length(basis_l.bases);][check_mom]; ket_only=ket_only)
+    if length(index) == 0
+        check_pos = typeof.(basis_l.bases) .== PositionBasis
+        check_mom = typeof.(basis_l.bases) .== MomentumBasis
+        if any(check_pos) && !any(check_mom)
+            index = [1:length(basis_l.bases);][check_pos]
+        elseif any(check_mom) && !any(check_pos)
+            index = [1:length(basis_l.bases);][check_mom]
+        else
+            throw(IncompatibleBases())
+        end
+    end
+    if all(typeof.(basis_l.bases[index]) .== PositionBasis)
+        @assert all(typeof.(basis_r.bases[index]) .== MomentumBasis)
+        transform_xp(basis_l, basis_r, index; ket_only=ket_only)
+    elseif all(typeof.(basis_l.bases[index]) .== MomentumBasis)
+        @assert all(typeof.(basis_r.bases[index]) .== PositionBasis)
+        transform_px(basis_l, basis_r, index; ket_only=ket_only)
     else
         throw(IncompatibleBases())
     end

--- a/src/particle.jl
+++ b/src/particle.jl
@@ -216,6 +216,8 @@ Abstract type for all implementations of FFT operators.
 """
 abstract type FFTOperator <: Operator end
 
+PlanFFT = Base.DFT.FFTW.cFFTWPlan
+
 """
     FFTOperators
 
@@ -225,10 +227,10 @@ that is a Ket or an Operator.
 type FFTOperators <: FFTOperator
     basis_l::Basis
     basis_r::Basis
-    fft_l!
-    fft_r!
-    fft_l2!
-    fft_r2!
+    fft_l!::PlanFFT
+    fft_r!::PlanFFT
+    fft_l2!::PlanFFT
+    fft_r2!::PlanFFT
     mul_before::Array{Complex128}
     mul_after::Array{Complex128}
 end
@@ -242,8 +244,8 @@ This is much more memory efficient when only working with Kets.
 type FFTKets <: FFTOperator
     basis_l::Basis
     basis_r::Basis
-    fft_l!
-    fft_r!
+    fft_l!::PlanFFT
+    fft_r!::PlanFFT
     mul_before::Array{Complex128}
     mul_after::Array{Complex128}
 end

--- a/test/test_particle.jl
+++ b/test/test_particle.jl
@@ -303,4 +303,16 @@ psi_x_fft = dagger(tensor(psi0_p...))*Tpx
 psi_x_fft2 = tensor((dagger.(psi0_p).*Tpx_sub)...)
 @test norm(psi_p_fft - psi_p_fft2) < 1e-15
 
+# Test composite basis of mixed type
+bc = FockBasis(2)
+psi_fock = fockstate(FockBasis(2), 1)
+psi1 = tensor(psi0_p[1], psi_fock, psi0_p[2])
+
+basis_l = tensor(basis_position[1], bc, basis_position[2])
+basis_r = tensor(basis_momentum[1], bc, basis_momentum[2])
+Txp = transform(basis_l, basis_r; ket_only=true)
+
+psi1_fft = Txp*psi1
+psi1_fft2 = tensor(Txp_sub[1]*psi0_p[1], psi_fock, Txp_sub[2]*psi0_p[2])
+@test norm(psi1_fft - psi1_fft2) < 1e-15
 end # testset

--- a/test/test_particle.jl
+++ b/test/test_particle.jl
@@ -230,7 +230,7 @@ Tpx_dense = DenseOperator(Tpx)
 @test 1e-5 > D(Txp_dense*rho0_pp*Tpx_dense, rho0_xx)
 
 # Test FFT in 2D
-N = [50, 40]
+N = [40, 30]
 xmin = [-32.5, -10π]
 xmax = [24.1, 9π]
 
@@ -307,12 +307,24 @@ psi_x_fft2 = tensor((dagger.(psi0_p).*Tpx_sub)...)
 bc = FockBasis(2)
 psi_fock = fockstate(FockBasis(2), 1)
 psi1 = tensor(psi0_p[1], psi_fock, psi0_p[2])
+psi2 = tensor(psi0_x[1], psi_fock, psi0_x[2])
 
 basis_l = tensor(basis_position[1], bc, basis_position[2])
 basis_r = tensor(basis_momentum[1], bc, basis_momentum[2])
 Txp = transform(basis_l, basis_r; ket_only=true)
+Tpx = transform(basis_r, basis_l; ket_only=true)
 
 psi1_fft = Txp*psi1
 psi1_fft2 = tensor(Txp_sub[1]*psi0_p[1], psi_fock, Txp_sub[2]*psi0_p[2])
 @test norm(psi1_fft - psi1_fft2) < 1e-15
+
+psi2_fft = Tpx*psi2
+psi2_fft2 = tensor(Tpx_sub[1]*psi0_x[1], psi_fock, Tpx_sub[2]*psi0_x[2])
+@test norm(psi2_fft - psi2_fft2) < 1e-15
+
+Txp = transform(basis_l, basis_r)
+Txp_sub = [transform(basis_position[i], basis_momentum[i]) for i=1:2]
+difference = (full(Txp) - tensor(full(Txp_sub[1]), full(one(bc)), full(Txp_sub[2]))).data
+@test isapprox(difference, zeros(difference); atol=1e-12)
+
 end # testset

--- a/test/test_particle.jl
+++ b/test/test_particle.jl
@@ -280,4 +280,27 @@ difference = (full(Txp) - identityoperator(DenseOperator, Txp.basis_l)*Txp).data
 
 @test full(Txp) == full(Txp_sub[1] ⊗ Txp_sub[2])
 
+# Test ket only FFTs
+Txp = transform(tensor(basis_position...), tensor(basis_momentum...); ket_only=true)
+Tpx = transform(tensor(basis_momentum...), tensor(basis_position...); ket_only=true)
+
+Txp_sub = [transform(basis_position[i], basis_momentum[i]; ket_only=true) for i=1:2]
+Tpx_sub = dagger.(Txp_sub)
+
+psi_p_fft = Tpx*tensor(psi0_x...)
+psi_p_fft2 = tensor((Tpx_sub.*psi0_x)...)
+@test norm(psi_p_fft - psi_p_fft2) < 1e-15
+
+psi_x_fft = Txp*tensor(psi0_p...)
+psi_x_fft2 = tensor((Txp_sub.*psi0_p)...)
+@test norm(psi_p_fft - psi_p_fft2) < 1e-15
+
+psi_p_fft = dagger(tensor(psi0_x...))*Txp
+psi_p_fft2 = tensor((dagger.(psi0_x).*Txp_sub)...)
+@test norm(psi_p_fft - psi_p_fft2) < 1e-15
+
+psi_x_fft = dagger(tensor(psi0_p...))*Tpx
+psi_x_fft2 = tensor((dagger.(psi0_p).*Tpx_sub)...)
+@test norm(psi_p_fft - psi_p_fft2) < 1e-15
+
 end # testset

--- a/test/test_printing.jl
+++ b/test/test_printing.jl
@@ -74,7 +74,7 @@ op = LazyTensor(b_fock ⊗ b_mb ⊗ b_spin, [1, 3], [SparseOperator(b_fock), Den
 bx = PositionBasis(-2, 2, 4)
 bp = MomentumBasis(bx)
 Tpx = transform(bp, bx)
-@test sprint(show, Tpx) == "FFTOperator(dim=4x4)
+@test sprint(show, Tpx) == "FFTOperators(dim=4x4)
   basis left:  Momentum(pmin=-3.141592653589793, pmax=3.141592653589793, N=4)
   basis right: Position(xmin=-2.0, xmax=2.0, N=4)"
 


### PR DESCRIPTION
This should implement all functionality required to solve #190.

Some more comments:
- Benchmarks need to be run once more.
- This is not a lazy implementation, but using `ket_only` makes it as efficient as saving a `Ket`. Going below this is only relevant if one is neglecting correlations.
- Things might not be entirely type stable here, so there might be some clean-up work to do.
- Using an `FFTOperator` in a `LazyTensor` will still throw the error as in #190. However, this can be avoided by rewriting things to a `LazyProduct`. We should maybe consider making this rewriting automatic or at least provide a more helpful error message.

EDIT:
Also, more rigorous tests are necessary.