### PR TITLE
Fix bug in steady-state and rename eps to tol everywhere

### DIFF
--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -15,7 +15,7 @@ Calculate steady state using long time master equation evolution.
         operator type.
 * `rho0=dm(basisstate(b))`: Initial density operator. If not given the
         ``|0⟩⟨0|`` state in respect to the choosen basis is used.
-* `eps=1e-3`: Tracedistance used as termination criterion.
+* `tol=1e-3`: Tracedistance used as termination criterion.
 * `hmin=1e-7`: Minimal time step used in the time evolution.
 * `rates=ones(N)`: Vector or matrix specifying the coefficients for the
         jump operators.
@@ -28,7 +28,7 @@ Calculate steady state using long time master equation evolution.
 """
 function master(H::Operator, J::Vector;
                 rho0::DenseOperator=tensor(basisstate(H.basis_l, 1), dagger(basisstate(H.basis_r, 1))),
-                hmin=1e-7,
+                hmin=1e-7, tol=1e-3,
                 rates::Union{Vector{Float64}, Matrix{Float64}, Void}=nothing,
                 Jdagger::Vector=dagger.(J),
                 fout::Union{Function,Void}=nothing,
@@ -40,7 +40,7 @@ function master(H::Operator, J::Vector;
                         display_intermediatesteps=true,
                         fout=fout,
                         steady_state = true,
-                        eps = eps, kwargs...)
+                        tol = tol, kwargs...)
 end
 
 """

--- a/src/timecorrelations.jl
+++ b/src/timecorrelations.jl
@@ -97,7 +97,7 @@ function spectrum(omega_samplepoints::Vector{Float64},
                 H::Operator, J::Vector, op::Operator;
                 rho0::DenseOperator=tensor(basisstate(H.basis_l, 1), dagger(basisstate(H.basis_r, 1))),
                 tol::Float64=1e-4,
-                rho_ss::DenseOperator=steadystate.master(H, J; tol=tol, rho0=rho0),
+                rho_ss::DenseOperator=steadystate.master(H, J; tol=tol, rho0=rho0)[end][end],
                 kwargs...)
     domega = minimum(diff(omega_samplepoints))
     dt = 2*pi/abs(omega_samplepoints[end] - omega_samplepoints[1])

--- a/src/timecorrelations.jl
+++ b/src/timecorrelations.jl
@@ -46,7 +46,7 @@ end
 
 function correlation(rho0::DenseOperator, H::Operator, J::Vector,
                      op1::Operator, op2::Operator;
-                     eps::Float64=1e-4, h0=10.,
+                     tol::Float64=1e-4, h0=10.,
                      rates::Union{Vector{Float64}, Matrix{Float64}, Void}=nothing,
                      Jdagger::Vector=dagger.(J),
                      kwargs...)
@@ -55,7 +55,7 @@ function correlation(rho0::DenseOperator, H::Operator, J::Vector,
     function fout(t, rho)
         expect(op1, rho)
     end
-    t,u = steadystate.master(H, J; rho0=op2rho0, eps=eps, h0=h0, fout=fout,
+    t,u = steadystate.master(H, J; rho0=op2rho0, tol=tol, h0=h0, fout=fout,
                        rates=rates, Jdagger=Jdagger, save_everystep=true,kwargs...)
 end
 
@@ -86,7 +86,7 @@ automatically.
 * `J`: Vector of jump operators.
 * `op`: Operator for which the auto-correlation function is calculated.
 * `rho0`: Initial density operator.
-* `eps=1e-4`: Tracedistance used as termination criterion.
+* `tol=1e-4`: Tracedistance used as termination criterion.
 * `rates=ones(N)`: Vector or matrix specifying the coefficients for the
         jump operators.
 * `Jdagger=dagger.(J)`: Vector containing the hermitian conjugates of the
@@ -96,8 +96,8 @@ automatically.
 function spectrum(omega_samplepoints::Vector{Float64},
                 H::Operator, J::Vector, op::Operator;
                 rho0::DenseOperator=tensor(basisstate(H.basis_l, 1), dagger(basisstate(H.basis_r, 1))),
-                eps::Float64=1e-4,
-                rho_ss::DenseOperator=steadystate.master(H, J; eps=eps, rho0=rho0),
+                tol::Float64=1e-4,
+                rho_ss::DenseOperator=steadystate.master(H, J; tol=tol, rho0=rho0),
                 kwargs...)
     domega = minimum(diff(omega_samplepoints))
     dt = 2*pi/abs(omega_samplepoints[end] - omega_samplepoints[1])
@@ -110,17 +110,17 @@ end
 
 function spectrum(H::Operator, J::Vector, op::Operator;
                 rho0::DenseOperator=tensor(basisstate(H.basis_l, 1), dagger(basisstate(H.basis_r, 1))),
-                eps::Float64=1e-4, h0=10.,
-                rho_ss::DenseOperator=steadystate.master(H, J; eps=eps)[end][end],
+                tol::Float64=1e-4, h0=10.,
+                rho_ss::DenseOperator=steadystate.master(H, J; tol=tol)[end][end],
                 kwargs...)
-    tspan, exp_values = correlation(rho_ss, H, J, dagger(op), op, eps=eps, h0=h0, kwargs...)
+    tspan, exp_values = correlation(rho_ss, H, J, dagger(op), op, tol=tol, h0=h0, kwargs...)
     dtmin = minimum(diff(tspan))
     T = tspan[end] - tspan[1]
     tspan = Float64[0.:dtmin:T;]
     n = length(tspan)
     omega = mod(n, 2) == 0 ? [-n/2:n/2-1;] : [-(n-1)/2:(n-1)/2;]
     omega .*= 2pi/T
-    return spectrum(omega, H, J, op; eps=eps, rho_ss=rho_ss, kwargs...)
+    return spectrum(omega, H, J, op; tol=tol, rho_ss=rho_ss, kwargs...)
 end
 
 

--- a/test/test_steadystate.jl
+++ b/test/test_steadystate.jl
@@ -42,7 +42,7 @@ Jdense = map(full, J)
 
 tout, ρt = timeevolution.master([0,100], ρ₀, Hdense, Jdense; reltol=1e-7)
 
-tss, ρss = steadystate.master(Hdense, Jdense; eps=1e-4)
+tss, ρss = steadystate.master(Hdense, Jdense; tol=1e-4)
 @test tracedistance(ρss[end], ρt[end]) < 1e-3
 
 ρss = steadystate.eigenvector(Hdense, Jdense)
@@ -57,7 +57,7 @@ Hp = η*(destroy(fockbasis) + create(fockbasis))
 Jp = [sqrt(2κ)*destroy(fockbasis)]
 n_an = η^2/κ^2
 
-tss,ρss = steadystate.master(Hp, Jp; rho0=ρ0_p, eps=1e-4)
+tss,ρss = steadystate.master(Hp, Jp; rho0=ρ0_p, tol=1e-4)
 nss = expect(create(fockbasis)*destroy(fockbasis), ρss[end])
 @test n_an - real(nss) < 1e-3
 
@@ -75,6 +75,6 @@ nss = expect(create(fockbasis)*destroy(fockbasis), ρss)
 function fout_wrong(t, x)
   @assert x == t
 end
-@test_throws MethodError steadystate.master(Hdense, Jdense; fout=fout_wrong)
+@test_throws AssertionError steadystate.master(Hdense, Jdense; fout=fout_wrong)
 
 end # testset

--- a/test/test_timecorrelations.jl
+++ b/test/test_timecorrelations.jl
@@ -39,7 +39,7 @@ exp_values = timecorrelations.correlation(tspan, ρ₀, H, J, dagger(op), op)
 
 ρ₀ = dm(Ψ₀)
 
-tout, exp_values2 = timecorrelations.correlation(ρ₀, H, J, dagger(op), op; eps=1e-5)
+tout, exp_values2 = timecorrelations.correlation(ρ₀, H, J, dagger(op), op; tol=1e-5)
 
 @test length(exp_values) == length(tspan)
 @test length(exp_values2) == length(tout)


### PR DESCRIPTION
This fixes a small bug that was caused by a missing definition of `eps` in `steadystate.master`. However, it was a bit tough to track down since `eps` is a function in `Base`. To avoid things like this in the future, all occurrences of `eps` have been renamed to `tol`.