### PR TITLE
Address Issue "Odd convention for the tensor product? "

### DIFF
--- a/src/QuantumOptics.jl
+++ b/src/QuantumOptics.jl
@@ -102,6 +102,7 @@ using .timeevolution
 using .metrics
 using .spectralanalysis
 using .timecorrelations
+using .printing
 
 
 end # module

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -120,7 +120,7 @@ show(stream::IO, x::Operator) = showoperatorheader(stream, x)
 function showquantumstatebody(stream::IO, x::Union{Ket,Bra})
     #the permutation is used to invert the order A x B = B.data x A.data to A.data x B.data
     perm = collect(length(basis(x).shape):-1:1)
-    if length(perm) == 1 || !_std_order
+    if length(perm) == 1
         Base.showarray(stream, round.(x.data, machineprecorder), false; header=false)
     else
         Base.showarray(stream,

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -1,5 +1,7 @@
 module printing
 
+export set_printing
+
 import Base: show
 
 using Compat
@@ -8,6 +10,25 @@ using ..operators, ..operators_dense, ..operators_sparse
 using ..operators_lazytensor, ..operators_lazysum, ..operators_lazyproduct
 using ..spin, ..fock, ..nlevel, ..particle, ..subspace, ..manybody, ..sparsematrix
 
+
+"""
+    QuantumOptics.set_printing(; standard_order, rounding_tol)
+
+Set options for REPL output.
+
+# Arguments
+* `standard_order=false`: For performance reasons, the order of the tensor
+    product is inverted, i.e. `tensor(a, b)=kron(b, a)`. When changing this
+    to `true`, the output shown in the REPL will exhibit the correct order.
+* `rounding_tol=1e-17`: Tolerance for floating point errors shown in the output.
+"""
+function set_printing(; standard_order::Bool=_std_order, rounding_tol::Real=_round_tol)
+    global _std_order = standard_order
+    global _round_tol = rounding_tol
+    global machineprecorder = Int32(round(-log10(_round_tol), 0))
+    nothing
+end
+set_printing(standard_order=false, rounding_tol=1e-17)
 
 function show(stream::IO, x::GenericBasis)
     if length(x.shape) == 1
@@ -65,12 +86,20 @@ end
 
 function show(stream::IO, x::Ket)
     write(stream, "Ket(dim=$(length(x.basis)))\n  basis: $(x.basis)\n")
-    showquantumstatebody(stream, x)
+    if !_std_order
+        Base.showarray(stream, x.data, false; header=false)
+    else
+        showquantumstatebody(stream, x)
+    end
 end
 
 function show(stream::IO, x::Bra)
     write(stream, "Bra(dim=$(length(x.basis)))\n  basis: $(x.basis)\n")
-   showquantumstatebody(stream, x)
+    if !_std_order
+        Base.showarray(stream, x.data, false; header=false)
+    else
+        showquantumstatebody(stream, x)
+    end
 end
 
 function showoperatorheader(stream::IO, x::Operator)
@@ -89,14 +118,13 @@ end
 show(stream::IO, x::Operator) = showoperatorheader(stream, x)
 
 function showquantumstatebody(stream::IO, x::Union{Ket,Bra})
-    machineprecorder = Int32(round(-log10(eps())-1,0))
     #the permutation is used to invert the order A x B = B.data x A.data to A.data x B.data
-    perm = collect(length(basis(x).shape):-1:1) 
-    if length(perm) == 1
-      Base.showarray(stream, round.(x.data,machineprecorder), false; header=false)
+    perm = collect(length(basis(x).shape):-1:1)
+    if length(perm) == 1 || !_std_order
+        Base.showarray(stream, round.(x.data, machineprecorder), false; header=false)
     else
-      Base.showarray(stream, 
-      round.(permutesystems(x,perm).data,machineprecorder), false; header=false)
+        Base.showarray(stream,
+        round.(permutesystems(x,perm).data, machineprecorder), false; header=false)
     end
 end
 
@@ -107,12 +135,11 @@ function permuted_densedata(x::DenseOperator)
     #padd the shape with additional x1 subsystems s.t. x has symmetric number of subsystems
     decomp = lbn > rbn ? [x.basis_l.shape; x.basis_r.shape; fill(1,lbn-rbn)] :
                          [x.basis_l.shape; fill(1,rbn-lbn); x.basis_r.shape]
-                         
+
     data = reshape(x.data, decomp...)
     data = permutedims(data, [perm; perm + length(perm)])
     data = reshape(data, length(x.basis_l), length(x.basis_r))
-    
-    machineprecorder = Int32(round(-log10(eps())-1,0))
+
     return round.(data, machineprecorder)
 end
 
@@ -123,10 +150,9 @@ function permuted_sparsedata(x::SparseOperator)
     #padd the shape with additional x1 subsystems s.t. x has symmetric number of subsystems
     decomp = lbn > rbn ? [x.basis_l.shape; x.basis_r.shape; fill(1,lbn-rbn)] :
                          [x.basis_l.shape; fill(1,rbn-lbn); x.basis_r.shape]
-                         
+
     data = sparsematrix.permutedims(x.data, decomp, [perm; perm + length(perm)])
-    
-    machineprecorder = Int32(round(-log10(eps())-1,0))
+
     return round.(data, machineprecorder)
 end
 
@@ -134,7 +160,11 @@ end
 function show(stream::IO, x::DenseOperator)
     showoperatorheader(stream, x)
     write(stream, "\n")
-    Base.showarray(stream, permuted_densedata(x), false; header=false)
+    if !_std_order
+        Base.showarray(stream, x.data, false; header=false)
+    else
+        Base.showarray(stream, permuted_densedata(x), false; header=false)
+    end
 end
 
 function show(stream::IO, x::SparseOperator)
@@ -142,7 +172,11 @@ function show(stream::IO, x::SparseOperator)
     if nnz(x.data) == 0
         write(stream, "\n    []")
     else
-        show(stream, permuted_sparsedata(x))
+        if !_std_order
+            show(stream, x.data)
+        else
+            show(stream, permuted_sparsedata(x))
+        end
     end
 end
 

--- a/test/test_printing.jl
+++ b/test/test_printing.jl
@@ -78,4 +78,47 @@ Tpx = transform(bp, bx)
   basis left:  Momentum(pmin=-3.141592653589793, pmax=3.141592653589793, N=4)
   basis right: Position(xmin=-2.0, xmax=2.0, N=4)"
 
+# Inversed tensor product ordering
+QuantumOptics.set_printing(standard_order=true)
+
+n = fockstate(b_fock, 1)
+@test sprint(show, n) == "Ket(dim=3)\n  basis: Fock(cutoff=2)\n 0.0+0.0im\n 1.0+0.0im\n 0.0+0.0im"
+
+spin1 = spindown(b_spin)
+spin2 = spinup(b_spin)
+state = n ⊗ spin1 ⊗ spin2
+state_data = kron(n.data, spin1.data, spin2.data)
+type_len = length("Complex{Float64}")
+state_data_str = join(split(sprint(show, state_data)[type_len+2:end-1], ','), "\n")
+@test sprint(show, state) == "Ket(dim=12)
+  basis: [Fock(cutoff=2) ⊗ Spin(1/2) ⊗ Spin(1/2)]\n "*state_data_str
+
+state_data_str = join(split(sprint(show, state_data')[type_len+2:end-1]), "\n ")
+@test sprint(show, dagger(state)) == "Bra(dim=12)
+  basis: [Fock(cutoff=2) ⊗ Spin(1/2) ⊗ Spin(1/2)]\n "*state_data_str
+
+op = dm(state)
+op_data = state_data * state_data'
+op_data_str1 = split(sprint(show, op_data)[type_len+2:end-1], ";")
+for i=1:length(op_data_str1)
+    op_data_str1[i] = join(split(op_data_str1[i]), "  ")
+end
+op_data_str = join(op_data_str1, "\n ")
+@test sprint(show, op) == "DenseOperator(dim=12x12)
+  basis: [Fock(cutoff=2) ⊗ Spin(1/2) ⊗ Spin(1/2)]\n "*op_data_str
+
+op = sparse(op)
+op_data = sparse(op_data)
+op_data_str = sprint(show, op_data)[4:end]
+@test sprint(show, op) == "SparseOperator(dim=12x12)
+  basis: [Fock(cutoff=2) ⊗ Spin(1/2) ⊗ Spin(1/2)]\n  "*op_data_str
+
+# Test switching back
+QuantumOptics.set_printing(standard_order=false)
+state_data = kron(spin2.data, spin1.data, n.data)
+state_data_str = join(split(sprint(show, state_data)[type_len+2:end-1], ','), "\n")
+@test sprint(show, state) == "Ket(dim=12)
+  basis: [Fock(cutoff=2) ⊗ Spin(1/2) ⊗ Spin(1/2)]\n "*state_data_str
+
+
 end # testset


### PR DESCRIPTION
I inverse the order of the subsystems, to get the standard output for tensor products. It's an easy fix for the problem.

Because rounding errors clutter the output for large matrices I round them to zero.

The data representation is unchanged with .data. It just changes the output for bra/ket and sparse/dense operators.