### PR TITLE
Fix bug in MCWF that prevented saving before/after jumps

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ Compat 0.52.0
 OrdinaryDiffEq 3.1.0
 DiffEqCallbacks 1.0
 StochasticDiffEq 3.0.0
+RecursiveArrayTools

--- a/test/test_timeevolution_mcwf.jl
+++ b/test/test_timeevolution_mcwf.jl
@@ -70,8 +70,9 @@ timeevolution.mcwf(T, Ψ₀, H, J; seed=UInt(2), reltol=1e-6, fout=fout)
 tout, Ψt = timeevolution.mcwf(T, Ψ₀, Hlazy, J; seed=UInt(1), reltol=1e-6)
 @test norm(Ψt[end] - Ψ) < 1e-5
 
-tout, Ψt = timeevolution.mcwf(T, Ψ₀, H, Jlazy; seed=UInt(1), reltol=1e-6)
-@test norm(Ψt[end] - Ψ) < 1e-5
+tout, Ψt2 = timeevolution.mcwf(T, Ψ₀, H, Jlazy; seed=UInt(1), reltol=1e-6, display_beforeevent=true, display_afterevent=true)
+@test norm(Ψt2[end] - Ψ) < 1e-5
+@test length(Ψt2) > length(Ψt)
 
 tout, Ψt = timeevolution.mcwf(T, Ψ₀, H, Jlazy./[sqrt(γ), sqrt(κ)]; seed=UInt(1), rates=[γ, κ], reltol=1e-6)
 @test norm(Ψt[end] - Ψ) < 1e-5


### PR DESCRIPTION
For reference: the bug is related to this issue https://github.com/JuliaDiffEq/DiffEqCallbacks.jl/issues/30
Once that is resolved, we can clean up the source code accordingly.