### PR TITLE
fix ishermitian for dense and sparse operator

### DIFF
--- a/src/operators_dense.jl
+++ b/src/operators_dense.jl
@@ -82,7 +82,7 @@ end
 
 operators.dagger(x::DenseOperator) = DenseOperator(x.basis_r, x.basis_l, x.data')
 
-operators.ishermitian(A::DenseOperator) = ishermitian(A.data)
+operators.ishermitian(A::DenseOperator) = (A.basis_l == A.basis_r) && ishermitian(A.data)
 
 operators.tensor(a::DenseOperator, b::DenseOperator) = DenseOperator(tensor(a.basis_l, b.basis_l), tensor(a.basis_r, b.basis_r), kron(b.data, a.data))
 

--- a/src/operators_sparse.jl
+++ b/src/operators_sparse.jl
@@ -67,7 +67,7 @@ Base.sparse(a::DenseOperator) = SparseOperator(a.basis_l, a.basis_r, sparse(a.da
 /(a::SparseOperator, b::Number) = SparseOperator(a.basis_l, a.basis_r, a.data/complex(b))
 
 operators.dagger(x::SparseOperator) = SparseOperator(x.basis_r, x.basis_l, x.data')
-operators.ishermitian(A::SparseOperator) = ishermitian(A.data)
+operators.ishermitian(A::SparseOperator) = (A.basis_l == A.basis_r) && ishermitian(A.data)
 
 operators.tensor(a::SparseOperator, b::SparseOperator) = SparseOperator(tensor(a.basis_l, b.basis_l), tensor(a.basis_r, b.basis_r), kron(b.data, a.data))
 operators.tensor(a::DenseOperator, b::SparseOperator) = SparseOperator(tensor(a.basis_l, b.basis_l), tensor(a.basis_r, b.basis_r), kron(b.data, a.data))

--- a/test/test_operators_dense.jl
+++ b/test/test_operators_dense.jl
@@ -333,4 +333,10 @@ x = Ket(b_r, dat)
 y = Bra(b_r, dat)
 @test dm(x) == dm(y)
 
+# Test Hermitian
+bspin = SpinBasis(1//2)
+bnlevel = NLevelBasis(2)
+@test ishermitian(DenseOperator(bspin, bspin, [1.0 im; -im 2.0])) == true
+@test ishermitian(DenseOperator(bspin, bnlevel, [1.0 im; -im 2.0])) == false
+
 end # testset

--- a/test/test_operators_sparse.jl
+++ b/test/test_operators_sparse.jl
@@ -336,5 +336,10 @@ dat = sprandop(b1, b1).data
 @test 2*SparseOperator(b1, dat) == SparseOperator(b1, dat)*2
 @test copy(op1) == deepcopy(op1)
 
+# Test Hermitian
+bspin = SpinBasis(1//2)
+bnlevel = NLevelBasis(2)
+@test ishermitian(SparseOperator(bspin, bspin, sparse([1.0 im; -im 2.0]))) == true
+@test ishermitian(SparseOperator(bspin, bnlevel, sparse([1.0 im; -im 2.0]))) == false
 
 end # testset


### PR DESCRIPTION
If an operator is Hermitian, both left and right bases should be same.