### PR TITLE
use ARPACKException from Arpack.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 WignerSymbols = "9f57e263-0b3d-5e2e-b1be-24f2bb48858b"
 
 [compat]
+Arpack = "≥ 0.3.1"
 DiffEqCallbacks = "≥ 2.5.0"
 OrdinaryDiffEq = "≥ 5.7.0"
 RecursiveArrayTools = "≥ 0.20.0"

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -72,7 +72,7 @@ function liouvillianspectrum(L::SparseSuperOperator; nev::Int = min(10, length(L
     d, v, nconv, niter, nmult, resid = try
         eigs(L.data; nev = nev, which = which, kwargs...)
     catch err
-        if isa(err, SingularException) || isa(err, ARPACKException)
+        if isa(err, SingularException) || isa(err, Arpack.ARPACKException)
             error("Arpack's eigs() algorithm failed; try using DenseOperators or change nev.")
         else
             rethrow(err)


### PR DESCRIPTION
ARPACKException is no longer defined in LinearAlgebra but instead in Arpack.jl (https://github.com/JuliaLinearAlgebra/Arpack.jl/pull/65).

This fixes the tests in the package on 1.3