### PR TITLE
Improved-BR-tensor

### DIFF
--- a/src/bloch_redfield_master.jl
+++ b/src/bloch_redfield_master.jl
@@ -1,5 +1,3 @@
-using Distributed
-
 """
     bloch_redfield_tensor(H, a_ops; J=[], use_secular=true, secular_cutoff=0.1)
 
@@ -90,7 +88,7 @@ function bloch_redfield_tensor(H::AbstractOperator, a_ops::Array; J=[], use_secu
     As = view(Iabs, :, 2)
     Bs = view(Iabs, :, 3)
 
-    @sync @distributed for (I, a, b) in collect(zip(Is, As, Bs))
+    for (I, a, b) in zip(Is, As, Bs)
 
         if use_secular
             Jcds = zeros(Int, size(Iabs))

--- a/src/bloch_redfield_master.jl
+++ b/src/bloch_redfield_master.jl
@@ -1,3 +1,5 @@
+using Distributed
+
 """
     bloch_redfield_tensor(H, a_ops; J=[], use_secular=true, secular_cutoff=0.1)
 
@@ -15,7 +17,6 @@ See QuTiP's documentation (http://qutip.org/docs/latest/guide/dynamics/dynamics-
 * `secular_cutoff=0.1`: Cutoff to allow a degree of partial secularization. Terms are discarded if they are greater than (dw\\_min * secular cutoff) where dw\\_min is the smallest (non-zero) difference between any two eigenenergies of H.
                         This argument is only taken into account if use_secular=true.
 """
-using Distributed
 function bloch_redfield_tensor(H::AbstractOperator, a_ops::Array; J=[], use_secular=true, secular_cutoff=0.1)
 
     # use the eigenbasis

--- a/src/bloch_redfield_master.jl
+++ b/src/bloch_redfield_master.jl
@@ -15,6 +15,7 @@ See QuTiP's documentation (http://qutip.org/docs/latest/guide/dynamics/dynamics-
 * `secular_cutoff=0.1`: Cutoff to allow a degree of partial secularization. Terms are discarded if they are greater than (dw\\_min * secular cutoff) where dw\\_min is the smallest (non-zero) difference between any two eigenenergies of H.
                         This argument is only taken into account if use_secular=true.
 """
+using Distributed
 function bloch_redfield_tensor(H::AbstractOperator, a_ops::Array; J=[], use_secular=true, secular_cutoff=0.1)
 
     # use the eigenbasis
@@ -88,7 +89,7 @@ function bloch_redfield_tensor(H::AbstractOperator, a_ops::Array; J=[], use_secu
     As = view(Iabs, :, 2)
     Bs = view(Iabs, :, 3)
 
-    for (I, a, b) in zip(Is, As, Bs)
+    @sync @distributed for (I, a, b) in collect(zip(Is, As, Bs))
 
         if use_secular
             Jcds = zeros(Int, size(Iabs))


### PR DESCRIPTION
Added some more concrete types and type stability fixes and cleaned up the main loop in the timeevolution.bloch_redfield_tensor function to increase efficiency.

This function is still the main bottleneck in my project and it seems like the main loop is still the most time consuming part of the function so I did look into parallelizing the loop but couldn't settle on a implementation I was happy with so have removed it for now. I may have another go at this in the future. 