### PR TITLE
Phase space functions declaration moved in QuantumOpticsBase.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumOptics"
 uuid = "6e0679c1-51ea-5a7c-ac74-d61b76210b0c"
-version = "v0.8.4"
+version = "v0.8.5"
 
 [deps]
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
@@ -21,7 +21,7 @@ Arpack = "0.5.1"
 DiffEqCallbacks = "2"
 FFTW = "1"
 OrdinaryDiffEq = "5"
-QuantumOpticsBase = "0.2.5"
+QuantumOpticsBase = "0.2.7"
 RecursiveArrayTools = "2"
 Reexport = "0.2, 1.0"
 StochasticDiffEq = "6"

--- a/src/QuantumOptics.jl
+++ b/src/QuantumOptics.jl
@@ -4,13 +4,14 @@ using Reexport
 @reexport using QuantumOpticsBase
 using SparseArrays, LinearAlgebra
 
-export qfunc, wigner, coherentspinstate, qfuncsu2, wignersu2, ylm,
-        eigenstates, eigenenergies, simdiag,
-        timeevolution, diagonaljumps, @skiptimechecks,
-        steadystate,
-        timecorrelations,
-        semiclassical,
-        stochastic
+export
+    ylm,
+    eigenstates, eigenenergies, simdiag,
+    timeevolution, diagonaljumps, @skiptimechecks,
+    steadystate,
+    timecorrelations,
+    semiclassical,
+    stochastic
 
 
 include("phasespace.jl")

--- a/src/phasespace.jl
+++ b/src/phasespace.jl
@@ -1,4 +1,10 @@
 import WignerSymbols: clebschgordan
+import QuantumOpticsBase:
+    qfunc,
+    wigner,
+    coherentspinstate,
+    qfuncsu2,
+    wignersu2
 
 """
     qfunc(a, α)


### PR DESCRIPTION
This is to accommodate the changes proposed in qojulia/QuantumOpticsBase.jl#15.
Added imports from QuantumOpticsBase.jl of phase space functions.