### PR TITLE
Allow real Hamiltonians in master and stochastic_master

### DIFF
--- a/src/master.jl
+++ b/src/master.jl
@@ -87,15 +87,15 @@ function master(tspan, rho0::T, H::AbstractOperator{B,B}, J::Vector;
         Hnh = copy(H)
         if isa(rates, Matrix)
             for i=1:length(J), j=1:length(J)
-                Hnh -= 0.5im*rates[i,j]*Jdagger[i]*J[j]
+                Hnh -= complex(eltype(H))(0.5im*rates[i,j])*Jdagger[i]*J[j]
             end
         elseif isa(rates, Vector)
             for i=1:length(J)
-                Hnh -= 0.5im*rates[i]*Jdagger[i]*J[i]
+                Hnh -= complex(eltype(H))(0.5im*rates[i])*Jdagger[i]*J[i]
             end
         else
             for i=1:length(J)
-                Hnh -= 0.5im*Jdagger[i]*J[i]
+                Hnh -= complex(eltype(H))(0.5im)*Jdagger[i]*J[i]
             end
         end
         Hnhdagger = dagger(Hnh)

--- a/src/master.jl
+++ b/src/master.jl
@@ -87,15 +87,15 @@ function master(tspan, rho0::T, H::AbstractOperator{B,B}, J::Vector;
         Hnh = copy(H)
         if isa(rates, Matrix)
             for i=1:length(J), j=1:length(J)
-                Hnh -= eltype(H)(0.5im*rates[i,j])*Jdagger[i]*J[j]
+                Hnh -= 0.5im*rates[i,j]*Jdagger[i]*J[j]
             end
         elseif isa(rates, Vector)
             for i=1:length(J)
-                Hnh -= eltype(H)(0.5im*rates[i])*Jdagger[i]*J[i]
+                Hnh -= 0.5im*rates[i]*Jdagger[i]*J[i]
             end
         else
             for i=1:length(J)
-                Hnh -= eltype(H)(0.5im)*Jdagger[i]*J[i]
+                Hnh -= 0.5im*Jdagger[i]*J[i]
             end
         end
         Hnhdagger = dagger(Hnh)

--- a/src/mcwf.jl
+++ b/src/mcwf.jl
@@ -106,11 +106,11 @@ function mcwf(tspan, psi0::T, H::AbstractOperator{B,B}, J::Vector;
         Hnh = copy(H)
         if isa(rates, Nothing)
             for i=1:length(J)
-                Hnh -= eltype(H)(0.5im)*Jdagger[i]*J[i]
+                Hnh -= complex(eltype(H))(0.5im)*Jdagger[i]*J[i]
             end
         else
             for i=1:length(J)
-                Hnh -= eltype(H)(0.5im*rates[i])*Jdagger[i]*J[i]
+                Hnh -= complex(eltype(H))(0.5im*rates[i])*Jdagger[i]*J[i]
             end
         end
         dmcwf_nh_(t, psi::T, dpsi::T) = dmcwf_nh(psi, Hnh, dpsi)

--- a/src/stochastic_master.jl
+++ b/src/stochastic_master.jl
@@ -54,15 +54,15 @@ function master(tspan, rho0::T, H::AbstractOperator{B,B},
         Hnh = copy(H)
         if isa(rates, Matrix)
             for i=1:length(J), j=1:length(J)
-                Hnh -= 0.5im*rates[i,j]*Jdagger[i]*J[j]
+                Hnh -= complex(eltype(H))(0.5im*rates[i,j])*Jdagger[i]*J[j]
             end
         elseif isa(rates, Vector)
             for i=1:length(J)
-                Hnh -= 0.5im*rates[i]*Jdagger[i]*J[i]
+                Hnh -= complex(eltype(H))(0.5im*rates[i])*Jdagger[i]*J[i]
             end
         else
             for i=1:length(J)
-                Hnh -= 0.5im*Jdagger[i]*J[i]
+                Hnh -= complex(eltype(H))(0.5im)*Jdagger[i]*J[i]
             end
         end
         Hnhdagger = dagger(Hnh)

--- a/src/stochastic_master.jl
+++ b/src/stochastic_master.jl
@@ -54,15 +54,15 @@ function master(tspan, rho0::T, H::AbstractOperator{B,B},
         Hnh = copy(H)
         if isa(rates, Matrix)
             for i=1:length(J), j=1:length(J)
-                Hnh -= eltype(H)(0.5im*rates[i,j])*Jdagger[i]*J[j]
+                Hnh -= 0.5im*rates[i,j]*Jdagger[i]*J[j]
             end
         elseif isa(rates, Vector)
             for i=1:length(J)
-                Hnh -= eltype(H)(0.5im*rates[i])*Jdagger[i]*J[i]
+                Hnh -= 0.5im*rates[i]*Jdagger[i]*J[i]
             end
         else
             for i=1:length(J)
-                Hnh -= eltype(H)(0.5im)*Jdagger[i]*J[i]
+                Hnh -= 0.5im*Jdagger[i]*J[i]
             end
         end
         Hnhdagger = dagger(Hnh)


### PR DESCRIPTION
This fixes an `InexactError` when trying to solve a master equation where `eltype(H) <: Real` as mentioned in [https://github.com/qojulia/QuantumOpticsBase.jl/pull/18](https://github.com/qojulia/QuantumOpticsBase.jl/pull/18). The issue is cause by calling `eltype(H)(0.5im)` which tries to convert `0.5im` to a real number.

I can see that similar calls to `eltype(::Operator)(im)` exist in other places such as here:

https://github.com/qojulia/QuantumOptics.jl/blob/e8a3ed060278bb7e4790474053cbe06ce55d656e/src/schroedinger.jl#L57-L60

which looks like it will fail if the initial state `psi0` given to `schoedinger` is real, but I don't know enough about these other sections of the code base to know if they are issues that need fixed.

At the moment, all convenience functions such as `fockstate`, `transition`, `create` etc. return complex valued operators so the only way to encounter these real-valued issues is to explicitly construct operators with `Operator(...)`. As such, I don't think these are major issues, but restricting to real operators seems to have some significant performance boosts in certain places (possibly due to linear algebra / type inference considerations?) so it might be worth thinking about whether real valued operators can become the default in certain places in the future.