### PR TITLE
Return concise error message if Ket coefficients are not compatible with timeevolution methods

### DIFF
--- a/src/master.jl
+++ b/src/master.jl
@@ -192,7 +192,10 @@ end
 
 # Automatically convert Ket states to density operators
 for f ∈ [:master,:master_h,:master_nh,:master_dynamic,:master_nh_dynamic]
-    @eval $f(tspan,psi0::Ket,args...;kwargs...) = $f(tspan,dm(psi0),args...;kwargs...)
+    @eval function $f(tspan,psi0::Ket,args...;kwargs...)
+        check_psi0(psi0)
+        $f(tspan,dm(psi0),args...;kwargs...)
+    end
 end
 
 # Non-hermitian Hamiltonian

--- a/src/mcwf.jl
+++ b/src/mcwf.jl
@@ -457,6 +457,7 @@ Check input of mcwf.
 """
 function check_mcwf(psi0, H, J, Jdagger, rates)
     # TODO: replace type checks by dispatch; make types of J known
+    check_psi0(psi0)
     isreducible = true
     if !(isa(H, DenseOpType) || isa(H, SparseOpType))
         isreducible = false

--- a/src/schroedinger.jl
+++ b/src/schroedinger.jl
@@ -5,7 +5,8 @@ Integrate Schroedinger equation to evolve states or compute propagators.
 
 # Arguments
 * `tspan`: Vector specifying the points of time for which output should be displayed.
-* `psi0`: Initial state vector (can be a bra or a ket) or initial propagator.
+* `psi0`: Initial state vector (can be a bra or a ket) or initial propagator. Has to be
+        complex array.
 * `H`: Arbitrary operator specifying the Hamiltonian.
 * `fout=nothing`: If given, this function `fout(t, psi)` is called every time
         an output should be displayed. ATTENTION: The state `psi` is neither
@@ -15,6 +16,7 @@ Integrate Schroedinger equation to evolve states or compute propagators.
 function schroedinger(tspan, psi0::T, H::AbstractOperator{B,B};
                 fout::Union{Function,Nothing}=nothing,
                 kwargs...) where {B,T<:Union{AbstractOperator{B,B},StateVector{B}}}
+    check_psi0(psi0)
     dschroedinger_(t, psi, dpsi) = dschroedinger!(dpsi, H, psi)
     x0 = psi0.data
     state = copy(psi0)
@@ -40,6 +42,7 @@ Integrate time-dependent Schroedinger equation to evolve states or compute propa
 function schroedinger_dynamic(tspan, psi0, f;
                 fout::Union{Function,Nothing}=nothing,
                 kwargs...)
+    check_psi0(psi0)
     dschroedinger_(t, psi, dpsi) = dschroedinger_dynamic!(dpsi, f, psi, t)
     x0 = psi0.data
     state = copy(psi0)
@@ -97,4 +100,10 @@ end
 function check_schroedinger(psi::Bra, H)
     check_multiplicable(psi, H)
     check_samebases(H)
+end
+
+function check_psi0(psi0)
+    if !(psi0 isa Ket{B, Array{T, 1}} where B<:Basis where T<:Complex)
+        error("Method only works for complex-valued initual wave functions.")
+    end
 end

--- a/src/schroedinger.jl
+++ b/src/schroedinger.jl
@@ -101,9 +101,3 @@ function check_schroedinger(psi::Bra, H)
     check_multiplicable(psi, H)
     check_samebases(H)
 end
-
-function check_psi0(psi0)
-    if !(psi0 isa Ket{B, Array{T, 1}} where B<:Basis where T<:Complex)
-        error("Method only works for complex-valued initual wave functions.")
-    end
-end

--- a/src/timeevolution_base.jl
+++ b/src/timeevolution_base.jl
@@ -74,6 +74,15 @@ function integrate(tspan, df, x0,
     integrate(tspan, df, x0, state, dstate, fout; kwargs...)
 end
 
+function check_psi0(psi0::Ket{B, T} where B<:Basis where T<:Array)
+    if !isa(psi0, Ket{B, Array{T, 1}} where B<:Basis where T<:Complex)
+        error("Method only works for complex-valued initual wave functions.")
+    end
+end
+
+function check_psi0(psi0)
+end
+
 struct SteadyStateCondtion{T,T2,T3}
     rho0::T
     tol::T2


### PR DESCRIPTION
Added a method `check_psi0` to `timeevolution_base` that uses Julia's type matching to check whether the coefficients of the initial wave function in time evolution methods are complex. If they are not, a short error message is generated that tells the user the coefficients should be converted to complex.

I've added this check to the `schroedinger`, `master`, and `mcwf` methods. During some unit tests, `schroedinger` methods are called with non-`Ket` datatypes as initial wave functions, so there's a generic `check_psi0` function that's called if the input is not of the `Ket` type. To make sure it passes the unit tests in `test_timeevolution_abstractdata.jl` I had to specify the input datatype to be
```Julia
check_psi0(psi0::Ket{B, T} where B<:Basis where T<:Array)
```
instead of just
```Julia
check_psi0(psi0::Ket)
````
In a sense the function is now checking the type twice, once to verify it's a `Ket{B, T}`, and then once more to make sure `T` is actually an array with complex coefficients. This seems suboptimal to me, but I couldn't immediately figure out a way to do it in one go. (For instance by having the value of the `T` that is matched in the function header available the function body.)

fixes #317 