### PR TITLE
Use recursive formula for binomial coefficient in CSS construction

### DIFF
--- a/src/phasespace.jl
+++ b/src/phasespace.jl
@@ -288,19 +288,31 @@ parametrization is not unique), similarly to a qubit on the
 Bloch sphere.
 """
 function coherentspinstate(b::SpinBasis, theta::Real, phi::Real)
+
     result = Ket(b)
     data = result.data
+
     N = length(b)-1
-    sinth = sin(0.5theta)
-    costh = cos(0.5theta)
-    expphi = exp(0.5im*phi)
-    expphi_con = conj(expphi)
-    sb = 1.0  # = recursive definition of √(N over n)
-    @inbounds for n=0:N
-        data[n+1] = sb * (sinth*expphi)^n * (costh*expphi_con)^(N-n)
-        sb = sb * √((N - n) / (n + 1))  # N over n = (N+1-n)/n (N over n-1)
+    α = sin(theta / 2) * exp(1im * phi / 2)
+    β = cos(theta / 2) * exp(-1im * phi / 2)
+
+    # forward pass: `c_n = sqrt(binomial(N, n)) * α^n` with `n  ≥ 0`,
+    # using recursive `binomial(N, n) = ((N+1-n)/n) * binomial(N, n-1)`
+    coefficient = 1.0
+    @inbounds for n = 1:N+1
+        data[n] = coefficient
+        coefficient *= α * sqrt((N + 1 - n) / n)
     end
+
+    # backward pass:  c_n *= β^(N-n)
+    factor = 1.0
+    @inbounds for n = N+1:-1:1
+        data[n] *= factor
+        factor *= β
+    end
+
     return result
+
 end
 
 """

--- a/src/phasespace.jl
+++ b/src/phasespace.jl
@@ -295,8 +295,10 @@ function coherentspinstate(b::SpinBasis, theta::Real, phi::Real)
     costh = cos(0.5theta)
     expphi = exp(0.5im*phi)
     expphi_con = conj(expphi)
+    sb = 1.0  # = recursive definition of √(N over n)
     @inbounds for n=0:N
-        data[n+1] = sqrt(binomial(N, n)) * (sinth*expphi)^n * (costh*expphi_con)^(N-n)
+        data[n+1] = sb * (sinth*expphi)^n * (costh*expphi_con)^(N-n)
+        sb = sb * √((N - n) / (n + 1))  # N over n = (N+1-n)/n (N over n-1)
     end
     return result
 end

--- a/test/test_phasespace.jl
+++ b/test/test_phasespace.jl
@@ -177,6 +177,13 @@ css = coherentspinstate(b,theta,phi)
 css0 = coherentspinstate(b,0,0)
 css2 = exp(-0.5im * phi * dense(sigmaz(b))) * exp(-0.5im * theta * dense(sigmay(b))) * css0
 @test norm(css - css2) < 1e-12
+b_big = SpinBasis(10000)  # > 2000 overflows recursive binomial un-moderated with α^n
+css_big = coherentspinstate(b_big,theta,phi)
+@test abs(1.0 - norm(css_big)) < 1e-12
+# we can go bigger than 10000 without overflowing (≈21000 is the limit), but
+# at some point we lose more precision to floating-point errors than we'd
+# normally want tolerate.
+@test abs(1 - norm(coherentspinstate(SpinBasis(21000),theta,phi))) < 1e-10
 
 
 ########### YLM test #############

--- a/test/test_phasespace.jl
+++ b/test/test_phasespace.jl
@@ -168,6 +168,17 @@ qsu2dm = sum(qfuncsu2(dmrs,res).*costhetam)*(π/res)^2
 @test isapprox(wsu2, 1.0, atol=1e-2)
 @test isapprox(wsu2dm, 1.0, atol=1e-2)
 
+
+# Test CSS for large spin number (#326)
+b = SpinBasis(35)  # S=35 overflows `binomial` function, e.g. binomial(70, 26)
+theta = π*rand()
+phi =2π*rand()
+css = coherentspinstate(b,theta,phi)
+css0 = coherentspinstate(b,0,0)
+css2 = exp(-0.5im * phi * dense(sigmaz(b))) * exp(-0.5im * theta * dense(sigmay(b))) * css0
+@test norm(css - css2) < 1e-12
+
+
 ########### YLM test #############
 res = 1000
 int = 0


### PR DESCRIPTION
This uses a recursive formula for the binomial coefficient in the construction of a `coherentspinstate` in order to avoid the overflow associated with the built-in `binomial` for larger values of S

Closes #326