### PR TITLE
added method for recast!

### DIFF
--- a/src/schroedinger.jl
+++ b/src/schroedinger.jl
@@ -56,6 +56,10 @@ a vector or a matrix with a matching size.
 """
 recast!(psi::StateVector{B,D},x::D) where {B, D} = (psi.data = x);
 recast!(x::D,psi::StateVector{B,D}) where {B, D} = nothing
+function recast!(proj::Operator{B1,B2,T},x::T) where {B1,B2,T}
+    proj.data = x
+end
+recast!(x::T,proj::Operator{B1,B2,T}) where {B1,B2,T} = nothing
 
 """
     dschroedinger!(dpsi, H, psi)


### PR DESCRIPTION
dynamics of Operator with different left and right basis would fail.
for example;
```
b1 = FockBasis(4)
b2 = NLevelBasis(2)
H(t,u) = number(b1) + destroy(b1) + create(b1)
ψ0 = projector(b1, SubspaceBasis(b1,[basisstate.([b1],1:2)...]))
ψ1 = Operator(ψ0.basis_l, FockBasis(1), ψ0.data)
timeevolution.schroedinger_dynamic(range(0,1,10), ψ1, H); # ok
timeevolution.schroedinger_dynamic(range(0,1,10), ψ0, H); # fail
```

`recast!` of an Operator type with different left and right basis fixes this.
This is useful for propagating a subset of states.