### PR TITLE
restricted Arpack version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 WignerSymbols = "9f57e263-0b3d-5e2e-b1be-24f2bb48858b"
 
 [compat]
-Arpack = "0.5.1"
+Arpack = "0.5.1 - 0.5.3"
 DiffEqCallbacks = "2"
 FFTW = "1"
 IterativeSolvers = "0.9"

--- a/test/test_steadystate.jl
+++ b/test/test_steadystate.jl
@@ -152,4 +152,25 @@ function fout_wrong(t, x)
 end
 @test_throws AssertionError steadystate.master(Hdense, Jdense; fout=fout_wrong)
 
+### Test Arpack version v0.5.4 failed
+ω_mech = 10.; Δ = -ω_mech
+g = 1.; η = 2.; κ = 1.;
+b_cav = FockBasis(4)
+b_mech = FockBasis(10)
+a = destroy(b_cav) ⊗ one(b_mech)
+at = create(b_cav) ⊗ one(b_mech)
+b = one(b_cav) ⊗ destroy(b_mech)
+bt = one(b_cav) ⊗ create(b_mech);
+# Hamilton operator
+H_cav = -Δ*at*a + η*(a + at)
+H_mech = ω_mech*bt*b
+H_int = -g*(bt+b)*at*a
+H = H_cav + H_mech + H_int
+J = [a]
+rates = [κ]
+
+ρ_end = steadystate.eigenvector(H,sqrt.(rates).*J;which=:SM)
+@test round(real(expect(bt*b,ρ_end)), digits=8) == 0.00088995
+@test round(real(expect(at*a,ρ_end)), digits=4) == 0.0406
+
 end # testset


### PR DESCRIPTION
Error for Arpack.jl version 0.5.4 in the docu example [Optomechanical cooling](https://docs.qojulia.org/examples/optomech-cooling/).