### PR TITLE
Propagating operators with schroedinger

### DIFF
--- a/src/schroedinger.jl
+++ b/src/schroedinger.jl
@@ -5,7 +5,7 @@ Integrate Schroedinger equation to evolve states or compute propagators.
 
 # Arguments
 * `tspan`: Vector specifying the points of time for which output should be displayed.
-* `psi0`: Initial state vector (can be a bra or a ket) or initial propagator.
+* `psi0`: Initial state vector (can be a bra or a ket) or an Operator from some basis to the basis of the Hamiltonian (psi0.basis_l == basis(H)).
 * `H`: Arbitrary operator specifying the Hamiltonian.
 * `fout=nothing`: If given, this function `fout(t, psi)` is called every time
         an output should be displayed. ATTENTION: The state `psi` is neither
@@ -31,7 +31,7 @@ Integrate time-dependent Schroedinger equation to evolve states or compute propa
 
 # Arguments
 * `tspan`: Vector specifying the points of time for which output should be displayed.
-* `psi0`: Initial state vector (can be a bra or a ket) or initial propagator.
+* `psi0`: Initial state vector (can be a bra or a ket) or an Operator from some basis to the basis of the Hamiltonian (psi0.basis_l == basis(H)).
 * `f`: Function `f(t, psi) -> H` returning the time and or state dependent Hamiltonian.
 * `fout=nothing`: If given, this function `fout(t, psi)` is called every time
         an output should be displayed. ATTENTION: The state `psi` is neither

--- a/src/schroedinger.jl
+++ b/src/schroedinger.jl
@@ -14,7 +14,7 @@ Integrate Schroedinger equation to evolve states or compute propagators.
 """
 function schroedinger(tspan, psi0::T, H::AbstractOperator{B,B};
                 fout::Union{Function,Nothing}=nothing,
-                kwargs...) where {B,T<:Union{AbstractOperator{B,B},StateVector{B}}}
+                kwargs...) where {B,Bo,T<:Union{AbstractOperator{B,Bo},StateVector{B}}}
     dschroedinger_(t, psi, dpsi) = dschroedinger!(dpsi, H, psi)
     tspan, psi0 = _promote_time_and_state(psi0, H, tspan) # promote only if ForwardDiff.Dual
     x0 = psi0.data

--- a/test/test_timeevolution_schroedinger.jl
+++ b/test/test_timeevolution_schroedinger.jl
@@ -88,7 +88,15 @@ t_sub2, psi_sub2 = timeevolution.schroedinger_dynamic(T, proj2, f; abstol=eps(),
 @test all(getfield.(psi_sub1, :data) .≈ getfield.(psi_sub2, :data))
 # check that data is the same
 @test all([hcat(q...) for q=eachrow(getfield.(hcat(psi_list...),:data))] .≈ getfield.(psi_sub1, :data) .≈ getfield.(psi_sub2, :data))
-
+## same for schroedinger
+t_list, psi_list = timeevolution.schroedinger.([T], subspace, f.(0.0, subspace); abstol=eps(), reltol=eps()) |> q->(getindex.(q,1), getindex.(q,2))
+t_sub1, psi_sub1 = timeevolution.schroedinger(T, proj1, f(0.0, proj1); abstol=eps(), reltol=eps())
+t_sub2, psi_sub2 = timeevolution.schroedinger(T, proj2, f(0.0, proj2); abstol=eps(), reltol=eps())
+@test t_list[1:end-1] == t_list[2:end] && t_list[1] == t_sub1 == t_sub2 # check that time vector is the same
+@test all(getfield.(psi_sub1, :basis_l) .== [proj1.basis_l]) && all(getfield.(psi_sub1, :basis_r) .== [proj1.basis_r]) # check that base is preserved
+@test all(getfield.(psi_sub2, :basis_l) .== [proj2.basis_l]) && all(getfield.(psi_sub2, :basis_r) .== [proj2.basis_r])
+@test all(getfield.(psi_sub1, :data) .≈ getfield.(psi_sub2, :data)) # check that data is independent of basis_r
+@test all([hcat(q...) for q=eachrow(getfield.(hcat(psi_list...),:data))] .≈ getfield.(psi_sub1, :data) .≈ getfield.(psi_sub2, :data)) # check that data is the same
 
 # test integration of propagator using 2 level system
 basis = SpinBasis(1//2)


### PR DESCRIPTION
Similar to https://github.com/qojulia/QuantumOptics.jl/pull/340.
Allow Operators with different left and right basis to propagate with `schroedinger` + tests.

Also, update this in the doc string of `schroedinger` and `schroedinger_dynamics`. Is the wording clear enough?