### PR TITLE
Support time-dependent operators in timeevolution

### DIFF
--- a/src/QuantumOptics.jl
+++ b/src/QuantumOptics.jl
@@ -23,6 +23,7 @@ module timeevolution
     include("schroedinger.jl")
     include("mcwf.jl")
     include("bloch_redfield_master.jl")
+    include("time_dependent_operators.jl")
 end
 module steadystate
     using QuantumOpticsBase

--- a/src/QuantumOptics.jl
+++ b/src/QuantumOptics.jl
@@ -19,11 +19,11 @@ module timeevolution
     export diagonaljumps, @skiptimechecks
 
     include("timeevolution_base.jl")
+    include("time_dependent_operators.jl")
     include("master.jl")
     include("schroedinger.jl")
     include("mcwf.jl")
     include("bloch_redfield_master.jl")
-    include("time_dependent_operators.jl")
 end
 module steadystate
     using QuantumOpticsBase

--- a/src/master.jl
+++ b/src/master.jl
@@ -145,6 +145,12 @@ H_{nh} = H - \\frac{i}{2} \\sum_k J^†_k J_k
 The given function can either be of the form `f(t, rho) -> (Hnh, Hnhdagger, J, Jdagger)`
 or `f(t, rho) -> (Hnh, Hnhdagger, J, Jdagger, rates)` For further information look
 at [`master_dynamic`](@ref).
+
+    timeevolution.master_dynamic(tspan, rho0, Hnh::AbstractTimeDependentOperator, J; <keyword arguments>)
+
+This version takes the non-hermitian Hamiltonian `Hnh` and jump operators `J` as time-dependent operators.
+The jump operators may be `<: AbstractTimeDependentOperator` or other types
+of operator.
 """
 function master_nh_dynamic(tspan, rho0::Operator, f;
                 rates=nothing,
@@ -153,6 +159,12 @@ function master_nh_dynamic(tspan, rho0::Operator, f;
     tmp = copy(rho0)
     dmaster_(t, rho, drho) = dmaster_nh_dynamic!(drho, f, rates, rho, tmp, t)
     integrate_master(tspan, dmaster_, rho0, fout; kwargs...)
+end
+
+function master_nh_dynamic(tspan, rho0::Operator, Hnh::AbstractTimeDependentOperator, J;
+    kwargs...)
+    f = master_nh_dynamic_function(Hnh, J)
+    master_nh_dynamic(tspan, rho0, f; kwargs...)
 end
 
 """
@@ -179,6 +191,12 @@ operators:
         permanent! It is still in use by the ode solver and therefore must not
         be changed.
 * `kwargs...`: Further arguments are passed on to the ode solver.
+
+    timeevolution.master_dynamic(tspan, rho0, H::AbstractTimeDependentOperator, J; <keyword arguments>)
+
+This version takes the Hamiltonian `H` and jump operators `J` as time-dependent operators.
+The jump operators may be `<: AbstractTimeDependentOperator` or other types
+of operator.
 """
 function master_dynamic(tspan, rho0::Operator, f;
                 rates=nothing,
@@ -189,6 +207,11 @@ function master_dynamic(tspan, rho0::Operator, f;
     integrate_master(tspan, dmaster_, rho0, fout; kwargs...)
 end
 
+function master_dynamic(tspan, rho0::Operator, H::AbstractTimeDependentOperator, J;
+    kwargs...)
+    f = master_h_dynamic_function(H, J)
+    master_dynamic(tspan, rho0, f; kwargs...)
+end
 
 # Automatically convert Ket states to density operators
 for f ∈ [:master,:master_h,:master_nh,:master_dynamic,:master_nh_dynamic]

--- a/src/mcwf.jl
+++ b/src/mcwf.jl
@@ -157,6 +157,12 @@ and therefore must not be changed.
 is returned. These correspond to the times at which a jump occured and the index
 of the jump operators with which the jump occured, respectively.
 * `kwargs...`: Further arguments are passed on to the ode solver.
+
+    mcwf_dynamic(tspan, psi0, H::AbstractTimeDependentOperator, J; <keyword arguments>)
+
+This version takes the Hamiltonian `H` and jump operators `J` as time-dependent operators.
+The jump operators may be `<: AbstractTimeDependentOperator` or other types
+of operator.
 """
 function mcwf_dynamic(tspan, psi0::Ket, f;
     seed=rand(UInt), rates=nothing,
@@ -172,8 +178,14 @@ function mcwf_dynamic(tspan, psi0::Ket, f;
         kwargs...)
 end
 
+function mcwf_dynamic(tspan, psi0::Ket, H::AbstractTimeDependentOperator, J; kwargs...)
+    f = mcfw_dynamic_function(H, J)
+    mcwf_dynamic(tspan, psi0, f; kwargs...)
+end
+
 """
     mcwf_nh_dynamic(tspan, rho0, f; <keyword arguments>)
+    mcwf_nh_dynamic(tspan, rho0, Hnh::AbstractTimeDependentOperator, J; <keyword arguments>)
 
 Calculate MCWF trajectory where the dynamic Hamiltonian is given in non-hermitian form.
 
@@ -190,6 +202,11 @@ function mcwf_nh_dynamic(tspan, psi0::Ket, f;
         display_beforeevent=display_beforeevent,
         display_afterevent=display_afterevent,
         kwargs...)
+end
+
+function mcwf_nh_dynamic(tspan, psi0::Ket, Hnh::AbstractTimeDependentOperator, J; kwargs...)
+    f = mcfw_nh_dynamic_function(Hnh, J)
+    mcwf_nh_dynamic(tspan, psi0, f; kwargs...)
 end
 
 """

--- a/src/schroedinger.jl
+++ b/src/schroedinger.jl
@@ -37,6 +37,10 @@ Integrate time-dependent Schroedinger equation to evolve states or compute propa
         an output should be displayed. ATTENTION: The state `psi` is neither
         normalized nor permanent! It is still in use by the ode solver and
         therefore must not be changed.
+
+    timeevolution.schroedinger_dynamic(tspan, psi0, H::AbstractTimeDependentOperator; fout)
+
+Instead of a function `f`, this takes a time-dependent operator `H`.
 """
 function schroedinger_dynamic(tspan, psi0, f;
                 fout::Union{Function,Nothing}=nothing,
@@ -47,6 +51,11 @@ function schroedinger_dynamic(tspan, psi0, f;
     state = copy(psi0)
     dstate = copy(psi0)
     integrate(tspan, dschroedinger_, x0, state, dstate, fout; kwargs...)
+end
+
+function schroedinger_dynamic(tspan, psi0::T, H::AbstractTimeDependentOperator;
+    kwargs...) where {B,Bp,T<:Union{AbstractOperator{B,Bp},StateVector{B}}}
+    schroedinger_dynamic(tspan, psi0, schroedinger_dynamic_function(H); kwargs...)
 end
 
 """

--- a/src/time_dependent_operators.jl
+++ b/src/time_dependent_operators.jl
@@ -1,0 +1,117 @@
+# Convert storage of heterogeneous stuff to tuples for maximal compilation
+# and to avoid runtime dispatch.
+_tuplify(o::TimeDependentSum) = TimeDependentSum(Tuple, o)
+_tuplify(o::LazySum) = LazySum(eltype(o.factors), o.factors, (o.operators...,))
+_tuplify(o::AbstractOperator) = o
+
+"""
+    schroedinger_dynamic_function(H::AbstractTimeDependentOperator)
+
+Creates a function `f(t, state) -> H(t)`. The `state` argument is ignored.
+
+This is the function expected by [`timeevolution.schroedinger_dynamic()`](@ref).
+"""
+function schroedinger_dynamic_function(H::AbstractTimeDependentOperator)
+    _getfunc(op) = (@inline _tdop_schroedinger_wrapper(t, _) = (op)(t))
+    Htup = _tuplify(H)
+    return _getfunc(Htup)
+end
+
+"""
+    master_h_dynamic_function(H::AbstractTimeDependentOperator, Js)
+
+Returns a function `f(t, state) -> H(t), Js, dagger.(Js)`.
+The `state` argument is ignored.
+
+This is the function expected by [`timeevolution.master_h_dynamic()`](@ref),
+where `H` is represents the Hamiltonian and `Js` are the (time independent) jump
+operators.
+"""
+function master_h_dynamic_function(H::AbstractTimeDependentOperator, Js)
+    Htup = _tuplify(H)
+    Js_tup = ((_tuplify(J) for J in Js)...,)
+
+    # TODO: We can do better than this for TimeDependentSum by only executing
+    #       coefficient functions once.
+    Jdags_tup = dagger.(Js_tup)
+    function _getfunc(Hop, Jops, Jdops)
+        return (@inline _tdop_master_wrapper_1(t, _) = ((Hop)(t), set_time!.(Jops, t), set_time!.(Jdops, t)))
+    end
+    return _getfunc(Htup, Js_tup, Jdags_tup)
+end
+
+"""
+    master_nh_dynamic_function(Hnh::AbstractTimeDependentOperator, Js)
+
+Returns a function `f(t, state) -> Hnh(t), Hnh(t)', Js, dagger.(Js)`.
+The `state` argument is currently ignored.
+
+This is the function expected by [`timeevolution.master_nh_dynamic()`](@ref),
+where `Hnh` is represents the non-Hermitian Hamiltonian and `Js` are the
+(time independent) jump operators.
+"""
+function master_nh_dynamic_function(Hnh::AbstractTimeDependentOperator, Js)
+    Hnhtup = _tuplify(Hnh)
+    Js_tup = ((_tuplify(J) for J in Js)...,)
+
+    # TODO: We can do better than this for TimeDependentSum by only executing
+    #       coefficient functions once.
+    Jdags_tup = dagger.(Js_tup)
+    Htdagup = dagger(Hnhtup)
+
+    function _getfunc(Hop, Hdop, Jops, Jdops)
+        return (@inline _tdop_master_wrapper_2(t, _) = ((Hop)(t), (Hdop)(t), set_time!.(Jops, t), set_time!.(Jdops, t)))
+    end
+    return _getfunc(Hnhtup, Htdagup, Js_tup, Jdags_tup)
+end
+
+"""
+    mcfw_dynamic_function(H, Js)
+
+Returns a function `f(t, state) -> H(t), Js, dagger.(Js)`.
+The `state` argument is currently ignored.
+
+This is the function expected by [`timeevolution.mcwf_dynamic()`](@ref),
+where `H` is represents the Hamiltonian and `Js` are the (time independent) jump
+operators.
+"""
+mcfw_dynamic_function(H, Js) = master_h_dynamic_function(H, Js)
+
+"""
+    mcfw_nh_dynamic_function(Hnh, Js)
+
+Returns a function `f(t, state) -> Hnh(t), Js, dagger.(Js)`.
+The `state` argument is currently ignored.
+
+This is the function expected by [`timeevolution.mcwf_dynamic()](@ref),
+where `Hnh` is represents the non-Hermitian Hamiltonian and `Js` are the (time
+independent) jump operators.
+"""
+mcfw_nh_dynamic_function(Hnh, Js) = master_h_dynamic_function(Hnh, Js)
+
+function schroedinger_dynamic(tspan, psi0::T, H::AbstractTimeDependentOperator;
+    kwargs...) where {B,Bp,T<:Union{AbstractOperator{B,Bp},StateVector{B}}}
+    schroedinger_dynamic(tspan, psi0, schroedinger_dynamic_function(H); kwargs...)
+end
+
+function master_dynamic(tspan, rho0::Operator, H::AbstractTimeDependentOperator, J;
+    kwargs...)
+    f = master_h_dynamic_function(H, J)
+    master_dynamic(tspan, rho0, f; kwargs...)
+end
+
+function master_nh_dynamic(tspan, rho0::Operator, Hnh::AbstractTimeDependentOperator, J;
+    kwargs...)
+    f = master_nh_dynamic_function(Hnh, J)
+    master_nh_dynamic(tspan, rho0, f; kwargs...)
+end
+
+function mcwf_dynamic(tspan, psi0::Ket, H::AbstractTimeDependentOperator, J; kwargs...)
+    f = mcfw_dynamic_function(H, J)
+    mcwf_dynamic(tspan, psi0, f; kwargs...)
+end
+
+function mcwf_nh_dynamic(tspan, psi0::Ket, Hnh::AbstractTimeDependentOperator, J; kwargs...)
+    f = mcfw_nh_dynamic_function(Hnh, J)
+    mcwf_nh_dynamic(tspan, psi0, f; kwargs...)
+end

--- a/src/time_dependent_operators.jl
+++ b/src/time_dependent_operators.jl
@@ -83,35 +83,8 @@ mcfw_dynamic_function(H, Js) = master_h_dynamic_function(H, Js)
 Returns a function `f(t, state) -> Hnh(t), Js, dagger.(Js)`.
 The `state` argument is currently ignored.
 
-This is the function expected by [`timeevolution.mcwf_dynamic()](@ref),
+This is the function expected by [`timeevolution.mcwf_dynamic()`](@ref),
 where `Hnh` is represents the non-Hermitian Hamiltonian and `Js` are the (time
 independent) jump operators.
 """
 mcfw_nh_dynamic_function(Hnh, Js) = master_h_dynamic_function(Hnh, Js)
-
-function schroedinger_dynamic(tspan, psi0::T, H::AbstractTimeDependentOperator;
-    kwargs...) where {B,Bp,T<:Union{AbstractOperator{B,Bp},StateVector{B}}}
-    schroedinger_dynamic(tspan, psi0, schroedinger_dynamic_function(H); kwargs...)
-end
-
-function master_dynamic(tspan, rho0::Operator, H::AbstractTimeDependentOperator, J;
-    kwargs...)
-    f = master_h_dynamic_function(H, J)
-    master_dynamic(tspan, rho0, f; kwargs...)
-end
-
-function master_nh_dynamic(tspan, rho0::Operator, Hnh::AbstractTimeDependentOperator, J;
-    kwargs...)
-    f = master_nh_dynamic_function(Hnh, J)
-    master_nh_dynamic(tspan, rho0, f; kwargs...)
-end
-
-function mcwf_dynamic(tspan, psi0::Ket, H::AbstractTimeDependentOperator, J; kwargs...)
-    f = mcfw_dynamic_function(H, J)
-    mcwf_dynamic(tspan, psi0, f; kwargs...)
-end
-
-function mcwf_nh_dynamic(tspan, psi0::Ket, Hnh::AbstractTimeDependentOperator, J; kwargs...)
-    f = mcfw_nh_dynamic_function(Hnh, J)
-    mcwf_nh_dynamic(tspan, psi0, f; kwargs...)
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ names = [
     "test_timeevolution_master.jl",
     "test_timeevolution_mcwf.jl",
     "test_timeevolution_bloch_redfield.jl",
+    "test_timeevolution_tdops.jl",
 
     "test_timeevolution_twolevel.jl",
     "test_timeevolution_pumpedcavity.jl",

--- a/test/test_timeevolution_tdops.jl
+++ b/test/test_timeevolution_tdops.jl
@@ -1,0 +1,77 @@
+using Test
+using QuantumOptics
+
+@testset "time-dependent operators" begin
+
+b = FockBasis(7)
+
+a = destroy(b)
+
+H0 = number(b)
+Hd = (a + a')
+H = TimeDependentSum(1.0=>H0, cos=>Hd)
+
+ts = [0.0, 0.4]
+ts_half = 0.5 * ts
+
+_getf = (H0, Hd) -> (t,_) -> H0 + cos(t)*Hd
+fman = _getf(H0, Hd)
+
+psi0 = basisstate(b, 1)
+ts_out, psis = timeevolution.schroedinger_dynamic(ts, psi0, H)
+# check this is not trivial
+@test !(psis[1].data ≈ psis[end].data)
+
+ts_out2, psis2 = timeevolution.schroedinger_dynamic(ts, psi0, fman)
+@test psis[end].data ≈ psis2[end].data
+
+Js = [TimeDependentSum(cos=>a)]
+Jdags = dagger.(Js)
+
+_getf = (H0, Hd, a) -> (t,_) -> (H0 + cos(t)*Hd, [cos(t)*a], [cos(t)*a'])
+fman = _getf(H0, Hd, a)
+
+ts_out, psis = timeevolution.mcwf_dynamic(ts, psi0, H, Js; seed=0)
+ts_out2, psis2 = timeevolution.mcwf_dynamic(ts, psi0, fman; seed=0)
+@test psis[end].data ≈ psis2[end].data
+
+rho0 = projector(psi0)
+ts_out, rhos = timeevolution.master_dynamic(ts, psi0, H, Js)
+ts_out2, rhos2 = timeevolution.master_dynamic(ts, psi0, fman)
+@test rhos[end].data ≈ rhos2[end].data
+
+Hnh = H - 0.5im * sum(J' * J for J in Js)
+
+_getf = (H0, Hd, a) -> (t,_) -> (
+    H0 + cos(t)*Hd - 0.5im * a' * a * cos(t)^2,
+    [cos(t)*a],
+    [cos(t)*a'])
+
+fman = _getf(H0, Hd, a)
+
+ts_out, psis = timeevolution.mcwf_nh_dynamic(ts, psi0, Hnh, Js; seed=0)
+ts_out2, psis2 = timeevolution.mcwf_nh_dynamic(ts, psi0, fman; seed=0)
+@test psis[end].data ≈ psis2[end].data
+
+_getf = (H0, Hd, a) -> (t,_) -> (
+    H0 + cos(t)*Hd - 0.5im * a' * a * cos(t)^2,
+    H0 + cos(t)*Hd + 0.5im * a' * a * cos(t)^2,
+    [cos(t)*a],
+    [cos(t)*a'])
+
+fman = _getf(H0, Hd, a)
+
+ts_out, rhos = timeevolution.master_nh_dynamic(ts, psi0, Hnh, Js)
+ts_out2, rhos2 = timeevolution.master_nh_dynamic(ts, psi0, fman)
+@test rhos[end].data ≈ rhos2[end].data
+
+# for sparse operators, we should not be allocating at each timestep
+allocs1 = @allocated timeevolution.schroedinger_dynamic(ts, psi0, H)
+allocs2 = @allocated timeevolution.schroedinger_dynamic(ts_half, psi0, H)
+@test allocs1 == allocs2
+
+allocs1 = @allocated timeevolution.master_nh_dynamic(ts, psi0, Hnh, Js)
+allocs2 = @allocated timeevolution.master_nh_dynamic(ts_half, psi0, Hnh, Js)
+@test allocs1 == allocs2
+
+end


### PR DESCRIPTION
This accompanies https://github.com/qojulia/QuantumOpticsBase.jl/pull/104. Tests won't pass until those changes are included.

Provides methods for "dynamic" time evolution that take time-dependent operators directly.