### PR TITLE
Adding hint for master solver function

### DIFF
--- a/src/QuantumOptics.jl
+++ b/src/QuantumOptics.jl
@@ -37,6 +37,7 @@ end
 include("timecorrelations.jl")
 include("spectralanalysis.jl")
 include("semiclassical.jl")
+include("debug.jl")
 module stochastic
     include("stochastic_base.jl")
     include("stochastic_definitions.jl")

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -1,0 +1,12 @@
+function __init__()
+    if isdefined(Base.Experimental, :register_error_hint)
+
+        Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
+            if exc.f == timeevolution.master
+                printstyled(io, "\nHint", color=:green)
+                print(io, ": If your Hamiltonian is time-dependent, then you may want to use master_dynamic instead of master to solve evolution.")
+            end
+        end
+
+    end
+end

--- a/src/master.jl
+++ b/src/master.jl
@@ -115,6 +115,8 @@ Time-evolution according to a master equation with a Liouvillian superoperator `
         permanent! It is still in use by the ode solver and therefore must not
         be changed.
 * `kwargs...`: Further arguments are passed on to the ode solver.
+
+See also: [`master_dynamic`](@ref)
 """
 function master(tspan, rho0::Operator, L::SuperOperator; fout=nothing, kwargs...)
     # Rewrite rho as Ket and L as Operator


### PR DESCRIPTION
Adding hint for master equation solver when there is a `MethodError`. I also referenced `master_dynamic` in the `see also` section of `master`. [#386](https://github.com/qojulia/QuantumOptics.jl/issues/386)