### PR TITLE
Adding hint for master and Schrödinger solver

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumOptics"
 uuid = "6e0679c1-51ea-5a7c-ac74-d61b76210b0c"
-version = "1.0.15"
+version = "1.0.16"
 
 [deps]
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"

--- a/src/QuantumOptics.jl
+++ b/src/QuantumOptics.jl
@@ -37,6 +37,7 @@ end
 include("timecorrelations.jl")
 include("spectralanalysis.jl")
 include("semiclassical.jl")
+include("debug.jl")
 module stochastic
     include("stochastic_base.jl")
     include("stochastic_definitions.jl")

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -1,12 +1,21 @@
 function __init__()
     if isdefined(Base.Experimental, :register_error_hint)
-
         Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
-            if exc.f == timeevolution.master
-                printstyled(io, "\nHint", color=:green)
-                print(io, ": If your Hamiltonian is time-dependent, then you may want to use master_dynamic instead of master to solve evolution.")
+            if (exc.f == timeevolution.master) && (length(argtypes) >= 3)
+                # Check if the given Hamiltonian is constant.
+                if !(QuantumOpticsBase.is_const(exc.args[3]))
+                    printstyled(io, "\nHint", color=:green)
+                    print(io, ": You are attempting to use a time-dependent Hamiltonian with a solver that assumes constant dynamics. To avoid errors, please use the _dynamic solvers instead, e.g. master_dynamic instead of master_dynamic.")
+                end
+            end
+
+            if (exc.f == timeevolution.schroedinger) && (length(argtypes) >= 3)
+                # Check if the given Hamiltonian is constant.
+                if !(QuantumOpticsBase.is_const(exc.args[3]))
+                    printstyled(io, "\nHint", color=:green)
+                    print(io, ": You are attempting to use a time-dependent Hamiltonian with a solver that assumes constant dynamics. To avoid errors, please use the _dynamic solvers instead, e.g. schroedinger_dynamic instead of schroedinger_dynamic.")
+                end
             end
         end
-
     end
 end

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -1,0 +1,12 @@
+function __init__()
+    if isdefined(Base.Experimental, :register_error_hint)
+
+        Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
+            if exc.f == timeevolution.master
+                printstyled(io, "\nHint", color=:green)
+                print(io, ": If your Hamiltonian is time-dependent, then you may want to use master_dynamic instead of master to solve evolution.")
+            end
+        end
+
+    end
+end

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -5,7 +5,7 @@ function __init__()
                 # Check if the given Hamiltonian is constant.
                 if !(QuantumOpticsBase.is_const(exc.args[3]))
                     printstyled(io, "\nHint", color=:green)
-                    print(io, ": You are attempting to use a time-dependent Hamiltonian with a solver that assumes constant dynamics. To avoid errors, please use the _dynamic solvers instead, e.g. master_dynamic instead of master_dynamic.")
+                    print(io, ": You are attempting to use a time-dependent Hamiltonian with a solver that assumes constant dynamics. To avoid errors, please use the dynamic solvers instead, e.g. `master_dynamic` instead of `master`.")
                 end
             end
 
@@ -13,7 +13,7 @@ function __init__()
                 # Check if the given Hamiltonian is constant.
                 if !(QuantumOpticsBase.is_const(exc.args[3]))
                     printstyled(io, "\nHint", color=:green)
-                    print(io, ": You are attempting to use a time-dependent Hamiltonian with a solver that assumes constant dynamics. To avoid errors, please use the _dynamic solvers instead, e.g. schroedinger_dynamic instead of schroedinger_dynamic.")
+                    print(io, ": You are attempting to use a time-dependent Hamiltonian with a solver that assumes constant dynamics. To avoid errors, please use the dynamic solvers instead, e.g. `schroedinger_dynamic` instead of `schroedinger`.")
                 end
             end
         end

--- a/src/master.jl
+++ b/src/master.jl
@@ -115,6 +115,8 @@ Time-evolution according to a master equation with a Liouvillian superoperator `
         permanent! It is still in use by the ode solver and therefore must not
         be changed.
 * `kwargs...`: Further arguments are passed on to the ode solver.
+
+See also: [`master_dynamic`](@ref)
 """
 function master(tspan, rho0::Operator, L::SuperOperator; fout=nothing, kwargs...)
     # Rewrite rho as Ket and L as Operator


### PR DESCRIPTION
I added hints for master and Schrödinger solver when there is a `MethodError`. I also referenced master_dynamic in the `see also` section of the master. https://github.com/qojulia/QuantumOptics.jl/issues/386