### PR TITLE
Don't tuplify time-dependent ops if types are homogenous

### DIFF
--- a/src/time_dependent_operators.jl
+++ b/src/time_dependent_operators.jl
@@ -14,7 +14,8 @@ function _tuplify(o::LazySum)
     end
     return LazySum(eltype(o.factors), o.factors, (o.operators...,))
 end
-_tuplify(o::AbstractVector{T}) where T = isconcretetype(T) ? (o...,) : o
+_tuplify(o::AbstractVector{T}) where T = isconcretetype(T) ? o : (o...,)
+_tuplify(o::Tuple) = o
 _tuplify(o::AbstractOperator) = o
 
 """

--- a/test/test_timeevolution_tdops.jl
+++ b/test/test_timeevolution_tdops.jl
@@ -1,6 +1,13 @@
 using Test
 using QuantumOptics
 
+function test_settime(op)
+    t = current_time(op)
+    set_time!(op, randn())
+    set_time!(op, t)
+    return nothing
+end
+
 @testset "time-dependent operators" begin
 
 b = FockBasis(7)
@@ -12,11 +19,17 @@ Hd = (a + a')
 
 # function and op types homogeneous
 H = TimeDependentSum(cos=>H0, cos=>Hd)
-@test timeevolution._tuplify(H) === H
+Htup = timeevolution._tuplify(H)
+@test Htup === H
+test_settime(Htup)
+@test (@allocated(test_settime)) == 0
 
 # op types not homogeneous
-H = TimeDependentSum(cos=>H0, cos=>dense(Hd))
-@test timeevolution._tuplify(H) !== H
+H = TimeDependentSum(cos=>H0, cos=>dense(Hd), cos=>LazySum(H0), cos=>LazySum(dense(Hd)))
+Htup = timeevolution._tuplify(H)
+@test Htup !== H
+test_settime(Htup)
+@test (@allocated(test_settime)) == 0
 
 H = TimeDependentSum(1.0=>H0, cos=>Hd)
 

--- a/test/test_timeevolution_tdops.jl
+++ b/test/test_timeevolution_tdops.jl
@@ -9,7 +9,19 @@ a = destroy(b)
 
 H0 = number(b)
 Hd = (a + a')
+
+# function and op types homogeneous
+H = TimeDependentSum(cos=>H0, cos=>Hd)
+@test timeevolution._tuplify(H) === H
+
+# op types not homogeneous
+H = TimeDependentSum(cos=>H0, cos=>dense(Hd))
+@test timeevolution._tuplify(H) !== H
+
 H = TimeDependentSum(1.0=>H0, cos=>Hd)
+
+# function types not homogeneous
+@test timeevolution._tuplify(H) !== H
 
 ts = [0.0, 0.4]
 ts_half = 0.5 * ts
@@ -54,6 +66,8 @@ ts_out, rhos = timeevolution.master_dynamic(ts, psi0, H, Js)
 ts_out2, rhos2 = timeevolution.master_dynamic(ts, psi0, fman)
 @test rhos[end].data ≈ rhos2[end].data
 
+set_time!(H, 0.0)
+set_time!.(Js, 0.0)
 Hnh = H - 0.5im * sum(J' * J for J in Js)
 
 _getf = (H0, Hd, a) -> (t,_) -> (

--- a/test/test_timeevolution_tdops.jl
+++ b/test/test_timeevolution_tdops.jl
@@ -117,4 +117,12 @@ allocs1 = @allocated timeevolution.master_nh_dynamic(ts, psi0, Hnh, Js)
 allocs2 = @allocated timeevolution.master_nh_dynamic(ts_half, psi0, Hnh, Js)
 @test allocs1 == allocs2
 
+Jstup = (Js...,)
+ts_out2, rhos2 = timeevolution.master_nh_dynamic(ts, psi0, Hnh, Jstup)
+@test rhos[end].data ≈ rhos2[end].data
+
+allocs1 = @allocated timeevolution.master_nh_dynamic(ts, psi0, Hnh, Jstup)
+allocs2 = @allocated timeevolution.master_nh_dynamic(ts_half, psi0, Hnh, Jstup)
+@test allocs1 == allocs2
+
 end


### PR DESCRIPTION
Requires https://github.com/qojulia/QuantumOpticsBase.jl/pull/171 to make allocs test pass.