### PR TITLE
Add derivative methods without caches

### DIFF
--- a/src/master.jl
+++ b/src/master.jl
@@ -280,6 +280,7 @@ end
 
 """
     dmaster_h!(drho, H, J, Jdagger, rates, rho, drho_cache)
+    dmaster_h!(drho, H, J, rates, rho)
 
 Update `drho` according to a master equation given in standard Lindblad form.
 A cached copy `drho_cache` of `drho` is used as a temporary saving step.
@@ -332,10 +333,11 @@ function dmaster_h!(drho, H, J, Jdagger, rates::AbstractMatrix, rho, drho_cache)
     return drho
 end
 
-dmaster_h!(drho, H, J, Jdagger, rates, rho) = dmaster_h!(drho, H, J, Jdagger, rates, rho, copy(drho))
+dmaster_h!(drho, H, J, rates, rho) = dmaster_h!(drho, H, J, dagger.(J), rates, rho, copy(drho))
 
 """
     dmaster_nh!(drho, Hnh, Hnh_dagger, J, Jdagger, rates, rho, drho_cache)
+    dmaster_nh!(drho, Hnh, J, rates, rho)
 
 Updates `drho` according to a master equation given in standard Lindblad form.
 The part of the Liuovillian which can be written as a commutator should be
@@ -375,7 +377,7 @@ function dmaster_nh!(drho, Hnh, Hnh_dagger, J, Jdagger, rates::AbstractMatrix, r
     return drho
 end
 
-dmaster_nh!(drho, Hnh, Hnh_dagger, J, Jdagger, rates, rho) = dmaster_nh!(drho, Hnh, Hnh_dagger, J, Jdagger, rates, rho, copy(drho))
+dmaster_nh!(drho, Hnh, J, rates, rho) = dmaster_nh!(drho, Hnh, dagger(Hnh), J, dagger.(J), rates, rho, copy(drho))
 
 """
     dmaster_liouville!(drho,L,rho)
@@ -393,6 +395,7 @@ end
 
 """
     dmaster_h_dynamic!(drho, f, rates, rho, drho_cache, t)
+    dmaster_h_dynamic!(drho, f, rates, rho, t)
 
 Computes the Hamiltonian and jump operators as `H,J,Jdagger=f(t,rho)` and
 update `drho` according to a master equation. Optionally, rates can also be
@@ -418,6 +421,7 @@ dmaster_h_dynamic!(drho, f::F, rates, rho, t) where {F} = dmaster_h_dynamic!(drh
 
 """
     dmaster_nh_dynamic!(drho, f, rates, rho, drho_cache, t)
+    dmaster_nh_dynamic!(drho, f, rates, rho, t)
 
 Computes the non-hermitian Hamiltonian and jump operators as
 `Hnh,Hnh_dagger,J,Jdagger=f(t,rho)` and update `drho` according to a master

--- a/src/master.jl
+++ b/src/master.jl
@@ -332,6 +332,8 @@ function dmaster_h!(drho, H, J, Jdagger, rates::AbstractMatrix, rho, drho_cache)
     return drho
 end
 
+dmaster_h!(drho, H, J, Jdagger, rates, rho) = dmaster_h!(drho, H, J, Jdagger, rates, rho, copy(drho))
+
 """
     dmaster_nh!(drho, Hnh, Hnh_dagger, J, Jdagger, rates, rho, drho_cache)
 
@@ -373,6 +375,8 @@ function dmaster_nh!(drho, Hnh, Hnh_dagger, J, Jdagger, rates::AbstractMatrix, r
     return drho
 end
 
+dmaster_nh!(drho, Hnh, Hnh_dagger, J, Jdagger, rates, rho) = dmaster_nh!(drho, Hnh, Hnh_dagger, J, Jdagger, rates, rho, copy(drho))
+
 """
     dmaster_liouville!(drho,L,rho)
 
@@ -410,6 +414,8 @@ function dmaster_h_dynamic!(drho, f::F, rates, rho, drho_cache, t) where {F}
     dmaster_h!(drho, H, J, Jdagger, rates_, rho, drho_cache)
 end
 
+dmaster_h_dynamic!(drho, f::F, rates, rho, t) where {F} = dmaster_h_dynamic!(drho, f, rates, rho, copy(drho), t)
+
 """
     dmaster_nh_dynamic!(drho, f, rates, rho, drho_cache, t)
 
@@ -432,6 +438,8 @@ function dmaster_nh_dynamic!(drho, f::F, rates, rho, drho_cache, t) where {F}
     QO_CHECKS[] && check_master(rho, Hnh, J, Jdagger, rates_)
     dmaster_nh!(drho, Hnh, Hnh_dagger, J, Jdagger, rates_, rho, drho_cache)
 end
+
+dmaster_nh_dynamic!(drho, f::F, rates, rho, t) where {F} = dmaster_nh_dynamic!(drho, f, rates, rho, copy(drho), t)
 
 
 function check_master(rho0, H, J, Jdagger, rates)

--- a/src/mcwf.jl
+++ b/src/mcwf.jl
@@ -270,6 +270,8 @@ function dmcwf_h_dynamic!(dpsi, f::F, rates, psi, dpsi_cache, t) where {F}
     dmcwf_h!(dpsi, H, J, Jdagger, rates_, psi, dpsi_cache)
 end
 
+dmcwf_h_dynamic!(dpsi, f::F, rates, psi, t) where {F} = dmcwf_h_dynamic!(dpsi, f, rates, psi, copy(dpsi), t)
+
 """
     dmcwf_nh_dynamic!(dpsi, f, psi, t)
 
@@ -556,6 +558,8 @@ function dmcwf_h!(dpsi, H, J, Jdagger, rates::AbstractVector, psi, dpsi_cache)
     end
     return dpsi
 end
+
+dmcwf_h!(dpsi, H, J, Jdagger, rates, psi) = dmcwf_h!(dpsi, H, J, Jdagger, rates, psi, copy(dpsi))
 
 """
     check_mcwf(psi0, H, J, Jdagger, rates)

--- a/src/mcwf.jl
+++ b/src/mcwf.jl
@@ -251,6 +251,7 @@ end
 
 """
     dmcwf_h_dynamic!(dpsi, f, rates, psi, dpsi_cache, t)
+    dmcwf_h_dynamic!(dpsi, f, rates, psi, t)
 
 Compute the Hamiltonian and jump operators as `H,J,Jdagger=f(t,psi)` and
 update `dpsi` according to a non-Hermitian Schrödinger equation.
@@ -534,6 +535,7 @@ end
 
 """
     dmcwf_h!(dpsi, H, J, Jdagger, rates, psi, dpsi_cache)
+    dmcwf_h!(dpsi, H, J, rates, psi)
 
 Update `dpsi` according to a non-hermitian Schrödinger equation. The
 non-hermitian Hamiltonian is given in two parts - the hermitian part H and
@@ -559,7 +561,7 @@ function dmcwf_h!(dpsi, H, J, Jdagger, rates::AbstractVector, psi, dpsi_cache)
     return dpsi
 end
 
-dmcwf_h!(dpsi, H, J, Jdagger, rates, psi) = dmcwf_h!(dpsi, H, J, Jdagger, rates, psi, copy(dpsi))
+dmcwf_h!(dpsi, H, J, rates, psi) = dmcwf_h!(dpsi, H, J, dagger.(J), rates, psi, copy(dpsi))
 
 """
     check_mcwf(psi0, H, J, Jdagger, rates)

--- a/src/semiclassical.jl
+++ b/src/semiclassical.jl
@@ -204,9 +204,10 @@ end
 
 """
     dmaster_h_dynamic!(dstate, fquantum, fclassical!, rates, state, tmp, t)
+    dmaster_h_dynamic!(dstate, fquantum, fclassical!, rates, state, t)
 
 Update the semiclassical state `dstate` according to a time-dependent,
-semiclassical master eqaution.
+semiclassical master equation.
 
 See also: [`semiclassical.master_dynamic`](@ref)
 """
@@ -217,11 +218,13 @@ function dmaster_h_dynamic!(dstate, fquantum::F, fclassical!::G, rates, state, t
     return dstate
 end
 
-dmaster_h_dynamic!(dstate, fquantum::F, fclassical!::G, rates, state, t) where {F,G}
-    = dmaster_h_dynamic!(dstate, fquantum, fclassical!, rates, state, copy(dstate), t)
+function dmaster_h_dynamic!(dstate, fquantum::F, fclassical!::G, rates, state, t) where {F,G}
+    dmaster_h_dynamic!(dstate, fquantum, fclassical!, rates, state, copy(dstate), t)
+end
 
 """
     dmcwf_h_dynamic!(dpsi, fquantum, fclassical!, rates, psi, tmp, t)
+    dmcwf_h_dynamic!(dpsi, fquantum, fclassical!, rates, psi, t)
 
 Update the semiclassical state `dpsi` according to a time-dependent, semiclassical
 and non-Hermitian Schrödinger equation (MCWF).
@@ -235,8 +238,9 @@ function dmcwf_h_dynamic!(dpsi, fquantum::F, fclassical!::G, rates, psi, tmp, t)
     return dpsi
 end
 
-dmcwf_h_dynamic!(dpsi, fquantum::F, fclassical!::G, rates, psi, t) where {F,G}
-    = dmcwf_h_dynamic!(dpsi, fquantum, fclassical!, rates, psi, copy(dpsi), t)
+function dmcwf_h_dynamic!(dpsi, fquantum::F, fclassical!::G, rates, psi, t) where {F,G}
+    dmcwf_h_dynamic!(dpsi, fquantum, fclassical!, rates, psi, copy(dpsi), t)
+end
 
 function jump_dynamic(rng, t, psi, fquantum::F, fclassical!::G, fjump_classical!::H, psi_new, probs_tmp, rates) where {F,G,H}
     result = fquantum(t, psi.quantum, psi.classical)

--- a/src/semiclassical.jl
+++ b/src/semiclassical.jl
@@ -299,7 +299,7 @@ function dmaster_h_dynamic!(dstate, fquantum::F, fclassical!::G, rates, state, t
 end
 
 function dmaster_h_dynamic!(dstate, fquantum::F, fclassical!::G, rates, state, t) where {F,G}
-    dmaster_h_dynamic!(dstate, fquantum, fclassical!, rates, state, copy(dstate), t)
+    dmaster_h_dynamic!(dstate, fquantum, fclassical!, rates, state, copy(dstate.quantum), t)
 end
 
 """
@@ -319,7 +319,7 @@ function dmcwf_h_dynamic!(dpsi, fquantum::F, fclassical!::G, rates, psi, tmp, t)
 end
 
 function dmcwf_h_dynamic!(dpsi, fquantum::F, fclassical!::G, rates, psi, t) where {F,G}
-    dmcwf_h_dynamic!(dpsi, fquantum, fclassical!, rates, psi, copy(dpsi), t)
+    dmcwf_h_dynamic!(dpsi, fquantum, fclassical!, rates, psi, copy(dpsi.quantum), t)
 end
 
 function jump_dynamic(rng, t, psi, fquantum::F, fclassical!::G, fjump_classical!::H, psi_new, probs_tmp, rates) where {F,G,H}

--- a/src/semiclassical.jl
+++ b/src/semiclassical.jl
@@ -217,6 +217,9 @@ function dmaster_h_dynamic!(dstate, fquantum::F, fclassical!::G, rates, state, t
     return dstate
 end
 
+dmaster_h_dynamic!(dstate, fquantum::F, fclassical!::G, rates, state, t) where {F,G}
+    = dmaster_h_dynamic!(dstate, fquantum, fclassical!, rates, state, copy(dstate), t)
+
 """
     dmcwf_h_dynamic!(dpsi, fquantum, fclassical!, rates, psi, tmp, t)
 
@@ -231,6 +234,9 @@ function dmcwf_h_dynamic!(dpsi, fquantum::F, fclassical!::G, rates, psi, tmp, t)
     fclassical!(dpsi.classical, psi.classical, psi.quantum, t)
     return dpsi
 end
+
+dmcwf_h_dynamic!(dpsi, fquantum::F, fclassical!::G, rates, psi, t) where {F,G}
+    = dmcwf_h_dynamic!(dpsi, fquantum, fclassical!, rates, psi, copy(dpsi), t)
 
 function jump_dynamic(rng, t, psi, fquantum::F, fclassical!::G, fjump_classical!::H, psi_new, probs_tmp, rates) where {F,G,H}
     result = fquantum(t, psi.quantum, psi.classical)

--- a/test/test_semiclassical.jl
+++ b/test/test_semiclassical.jl
@@ -162,6 +162,18 @@ tout5, ut = semiclassical.mcwf_dynamic(T,ψ0,fquantum,fclassical,fjump_classical
 
 @test ψt1[end].classical[2] == u0[2] + 1.0
 
+# Test no cache derivative methods
+
+t0, t1 = (0.0, 1.0)
+
+fmaster_h_dynamic!(dstate, state, p, t) = semiclassical.dmaster_h_dynamic!(dstate, fquantum, fclassical!, nothing, state, t)
+prob_master_h_dynamic! = ODEProblem(fmaster_h_dynamic!, ψ0, (t0, t1))
+@test_nowarn sol_master_h_dynamic! = solve(prob_master_h_dynamic!, DP5(); save_everystep=false)
+
+fmcwf_h_dynamic!(dpsi, psi, p, t) = semiclassical.dmcwf_h_dynamic!(dpsi, fquantum, fclassical!, nothing, psi, t)
+prob_mcwf_h_dynamic! = ODEProblem(fmcwf_h_dynamic!, ψ0, (t0, t1))
+@test_nowarn sol_mcwf_h_dynamic! = solve(prob_mcwf_h_dynamic!, DP5(); save_everystep=false)
+
 # Test classical jump behavior
 before_jump = findfirst(t -> !(t∈T), tout3)
 after_jump = findlast(t-> !(t∈T), tout4)

--- a/test/test_semiclassical.jl
+++ b/test/test_semiclassical.jl
@@ -2,6 +2,7 @@ using Test
 using QuantumOptics
 using LinearAlgebra
 using QuantumOpticsBase: IncompatibleBases
+using OrdinaryDiffEq
 
 @testset "semiclassical" begin
 
@@ -166,12 +167,13 @@ tout5, ut = semiclassical.mcwf_dynamic(T,ψ0,fquantum,fclassical,fjump_classical
 # Test no cache derivative methods
 
 t0, t1 = (0.0, 1.0)
+rho0 = semiclassical.State(dm(spinup(ba)⊗fockstate(bf,0)),u0)
 
-fmaster_h_dynamic!(dstate, state, p, t) = semiclassical.dmaster_h_dynamic!(dstate, fquantum, fclassical!, nothing, state, t)
-prob_master_h_dynamic! = ODEProblem(fmaster_h_dynamic!, ψ0, (t0, t1))
+fmaster_h_dynamic!(dstate, state, p, t) = semiclassical.dmaster_h_dynamic!(dstate, fquantum_master, fclassical, nothing, state, t)
+prob_master_h_dynamic! = ODEProblem(fmaster_h_dynamic!, rho0, (t0, t1))
 @test_nowarn sol_master_h_dynamic! = solve(prob_master_h_dynamic!, DP5(); save_everystep=false)
 
-fmcwf_h_dynamic!(dpsi, psi, p, t) = semiclassical.dmcwf_h_dynamic!(dpsi, fquantum, fclassical!, nothing, psi, t)
+fmcwf_h_dynamic!(dstate, state, p, t) = semiclassical.dmcwf_h_dynamic!(dstate, fquantum, fclassical, nothing, state, t)
 prob_mcwf_h_dynamic! = ODEProblem(fmcwf_h_dynamic!, ψ0, (t0, t1))
 @test_nowarn sol_mcwf_h_dynamic! = solve(prob_mcwf_h_dynamic!, DP5(); save_everystep=false)
 

--- a/test/test_timeevolution_mcwf.jl
+++ b/test/test_timeevolution_mcwf.jl
@@ -115,6 +115,20 @@ tout, Ψt = timeevolution.mcwf_nh(T, Ψ₀, Hnh_dense, J; seed=UInt(1), reltol=1
 tout, Ψt = timeevolution.mcwf_nh(T, Ψ₀, Hnh, J; seed=UInt(2), reltol=1e-6)
 @test norm(Ψt[end]-Ψ) > 0.1
 
+# Test no cache derivative methods
+
+function Ht(t, psi)
+    H*exp(-(5-t)^2), J, dagger.(J)
+end
+t0, t1 = (0.0, 1.0)
+
+fmcwf_h_dynamic!(dpsi, psi, p, t) = timeevolution.dmcwf_h_dynamic!(dpsi, Ht, nothing, psi, t)
+prob_mcwf_h_dynamic! = ODEProblem(fmcwf_h_dynamic!, Ψ₀, (t0, t1))
+@test_nowarn sol_mcwf_h_dynamic! = solve(prob_mcwf_h_dynamic!, DP5(); save_everystep=false)
+
+fmcwf_h!(dpsi, psi, p, t) = timeevolution.dmcwf_h!(dpsi, H, J, nothing, psi)
+prob_mcwf_h! = ODEProblem(fmcwf_h!, Ψ₀, (t0, t1))
+@test_nowarn sol_mcwf_h! = solve(prob_mcwf_h!, DP5(); save_everystep=false)
 
 
 # Test convergence to master solution


### PR DESCRIPTION
Addresses #406. This PR makes defining in-place functions straightforward (that is, the user does not have to input caches or adjoints of operators) for any solver. This is important given the recent merges (#404, https://github.com/qojulia/QuantumOpticsBase.jl/pull/172) to have a SciML interface in QO.jl. The following example illustrates the motivation for this PR.

```
b = FockBasis(10)
psi0 = fockstate(b, 4)
rho0 = dm(psi0)
H = number(b)
J = [destroy(b), create(b)]
rates = [0.7, 0.5]
```

Before, we would have to define an in-place function as
```
f!(drho, rho, p, t) = timeevolution.dmaster_h!(drho, H, J, dagger.(J), rates, rho, copy(drho))
```
Now, we can instead simply write
```
f!(drho, rho, p, t) = timeevolution.dmaster_h!(drho, H, J, rates, rho)
```

And solve the ODE as follows:
```
prob = ODEProblem(f!, rho0, (0.0, 1.0))
sol = solve(prob, DP5(); save_everystep=false)
```
