### PR TITLE
Fix #432

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -53,6 +52,7 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -61,4 +61,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
-test = ["Aqua", "FiniteDiff", "JET", "LinearAlgebra", "SparseArrays", "Random", "Test", "TestItemRunner"]
+test = ["Aqua", "FiniteDiff", "ForwardDiff", "JET", "LinearAlgebra", "SparseArrays", "Random", "Test", "TestItemRunner"]


### PR DESCRIPTION
#432 This fix properly uses `DiffEqBase.anyeltypedual` and `DiffEqBase.isdualtype` rather than `DiffEqBase.promote_dual` defined in `ext/DiffEqBaseForwardDiffExt.jl`. It also removes ForwardDiff.jl as a direct dependency.

Pinging @Krastanov or @amilsted for review.