### PR TITLE
Add `embed_lazy` API

### DIFF
--- a/docs/src/quantumobjects/operators.md
+++ b/docs/src/quantumobjects/operators.md
@@ -113,6 +113,19 @@ H = LazySum(LazyProduct(dagger(sm1), sm1), LazyProduct(dagger(sm2), sm2))
 nothing # hide
 ```
 
+For the common case of embedding local operators into a composite basis while preserving the lazy structure, use [`embed_lazy`](@ref) instead of [`embed`](@ref):
+
+```@example operators
+sx = sigmax(b0)
+sz = sigmaz(b0)
+
+H_lazy = embed_lazy(b, 1, sx) + embed_lazy(b, 2, sz)
+H_sum = embed_lazy(b, 1, LazySum(sx, 0.5 * sz))
+nothing # hide
+```
+
+Compared with [`embed`](@ref), `embed_lazy` keeps the result in lazy form and defers matrix materialization until you call [`dense`](@ref) or [`sparse`](@ref). That makes it a better fit when the embedded operator is used directly in a Hamiltonian or multiplied with a state.
+
 **Note**
 
 

--- a/src/QuantumOptics.jl
+++ b/src/QuantumOptics.jl
@@ -12,9 +12,11 @@ export
     steadystate,
     timecorrelations,
     semiclassical,
-    stochastic
+    stochastic,
+    embed_lazy
 
 
+include("embed_lazy.jl")
 include("phasespace.jl")
 module timeevolution
     export diagonaljumps, @skiptimechecks

--- a/src/embed_lazy.jl
+++ b/src/embed_lazy.jl
@@ -1,12 +1,4 @@
-# src/embed_lazy.jl
-# Lazy embedding utilities for QuantumOptics.
-#
-# embed_lazy is defined here (not in QuantumOpticsBase, which does not provide
-# this function) and is exported from the QuantumOptics module.
-
 using QuantumOpticsBase
-
-# ====================== Internal Basis Checks ======================
 
 function _embed_lazy_check_basis(basis_l::CompositeBasis, basis_r::CompositeBasis,
                                  index::Integer, op::AbstractOperator)
@@ -57,8 +49,6 @@ compatibility check), since no embedding is needed.
 """
 function embed_lazy end
 
-# --- AbstractOperator → LazyTensor ---
-
 function embed_lazy(basis::CompositeBasis, index::Integer, op::AbstractOperator)
     _embed_lazy_check_basis(basis, basis, index, op)
     LazyTensor(basis, index, op)
@@ -70,7 +60,7 @@ function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
     LazyTensor(basis_l, basis_r, index, op)
 end
 
-# --- LazyTensor (single-index shortcut) ---
+# LazyTensor (single-index shortcut)
 
 function embed_lazy(basis::CompositeBasis, index::Integer, op::LazyTensor)
     length(op.operators) == 1 ||
@@ -85,7 +75,7 @@ function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
     LazyTensor(basis_l, basis_r, index, first(values(op.operators)), op.factor)
 end
 
-# --- LazyTensor (multi-index) ---
+# LazyTensor (multi-index)
 
 function embed_lazy(basis::CompositeBasis, indices, op::LazyTensor)
     _embed_lazy_check_basis(basis, basis, indices, op.operators)
@@ -97,8 +87,6 @@ function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
     _embed_lazy_check_basis(basis_l, basis_r, indices, op.operators)
     LazyTensor(basis_l, basis_r, indices, op.operators, op.factor)
 end
-
-# --- LazySum ---
 
 function embed_lazy(basis::CompositeBasis, index::Integer, op::LazySum)
     LazySum(basis, basis, op.factors,
@@ -121,8 +109,6 @@ function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
     LazySum(basis_l, basis_r, op.factors,
             map(o -> embed_lazy(basis_l, basis_r, indices, o), op.operators))
 end
-
-# --- TimeDependentSum ---
 
 function embed_lazy(basis::CompositeBasis, index::Integer, op::TimeDependentSum)
     TimeDependentSum(QuantumOpticsBase.coefficients(op),
@@ -150,8 +136,22 @@ function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
                      init_time = current_time(op))
 end
 
-# --- Vector of operators → LazyTensor ---
+# Disambiguating method: CompositeBasis + single Integer index + vector of ops
+function embed_lazy(basis::CompositeBasis, index::Integer,
+                    operators::AbstractVector{<:AbstractOperator})
+    length(operators) == 1 ||
+        throw(ArgumentError("embed_lazy with a single index requires a single-element operator vector."))
+    embed_lazy(basis, index, only(operators))
+end
 
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis, index::Integer,
+                    operators::AbstractVector{<:AbstractOperator})
+    length(operators) == 1 ||
+        throw(ArgumentError("embed_lazy with a single index requires a single-element operator vector."))
+    embed_lazy(basis_l, basis_r, index, only(operators))
+end
+
+# Multi-index versions
 function embed_lazy(basis::CompositeBasis, indices,
                     operators::AbstractVector{<:AbstractOperator})
     _embed_lazy_check_basis(basis, basis, indices, operators)
@@ -164,7 +164,7 @@ function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis, indices,
     LazyTensor(basis_l, basis_r, indices, Tuple(operators))
 end
 
-# ====================== Non-Composite Basis (identity embed) ======================
+# Non-Composite Basis (identity embed)
 
 function embed_lazy(b::Basis, index::Integer, op::AbstractOperator)
     _embed_lazy_check_basis(b, index, op)
@@ -194,7 +194,7 @@ function embed_lazy(b::Basis, index::Integer,
     operators
 end
 
-# ====================== Convenience (no-index) ======================
+# Convenience (no-index)
 
 embed_lazy(b::Basis, op) = embed_lazy(b, 1, op)
 embed_lazy(b::CompositeBasis, op) = embed_lazy(b, 1, op)

--- a/src/embed_lazy.jl
+++ b/src/embed_lazy.jl
@@ -1,200 +1,132 @@
 using QuantumOpticsBase
 
-function _embed_lazy_check_basis(basis_l::CompositeBasis, basis_r::CompositeBasis,
-                                 index::Integer, op::AbstractOperator)
-    (basis_l.bases[index] == op.basis_l && basis_r.bases[index] == op.basis_r) ||
-        throw(IncompatibleBases())
-end
-
-function _embed_lazy_check_basis(basis_l::CompositeBasis, basis_r::CompositeBasis,
-                                 indices, operators)
-    length(indices) == length(operators) ||
-        throw(ArgumentError("embed_lazy requires length(indices) == length(operators)."))
-    for (index, op) in zip(indices, operators)
-        basis_l.bases[index] == op.basis_l || throw(IncompatibleBases())
-        basis_r.bases[index] == op.basis_r || throw(IncompatibleBases())
-    end
-    return nothing
-end
-
-function _embed_lazy_check_basis(b::Basis, index::Integer, op::AbstractOperator)
-    index == 1 || throw(ArgumentError("For non-composite basis, embed index must be 1."))
-    b == op.basis_l || throw(IncompatibleBases())
-    return nothing
-end
-
-function _embed_lazy_check_basis(b::Basis, index::Integer,
-                                 ops::Union{Tuple,AbstractVector})
-    index == 1 || throw(ArgumentError("For non-composite basis, embed index must be 1."))
-    for op in ops
-        b == op.basis_l || throw(IncompatibleBases())
-    end
-    return nothing
-end
-
-# ====================== embed_lazy ======================
-
 """
     embed_lazy(basis, index, op)
     embed_lazy(basis_l, basis_r, index, op)
     embed_lazy(basis, indices, operators)
 
-Embed `op` into `basis` at position `index` (or positions `indices`) using
-lazy operators (`LazyTensor`, `LazySum`). Unlike `embed`, this avoids
-materialising the full tensor-product operator and therefore scales much better
-for large composite systems.
+Embed `op` into a composite `basis` at position `index` (or positions `indices`)
+without materialising the full tensor-product matrix. Returns a `LazyTensor` or
+`LazySum` that defers allocation until you call `dense` or `sparse`.
 
-For a non-composite `Basis` the operator is returned unchanged (after a
-compatibility check), since no embedding is needed.
+On a non-composite `Basis` the operator is returned as-is after a compatibility check.
+
+See also: [`embed`](@ref)
 """
 function embed_lazy end
 
-function embed_lazy(basis::CompositeBasis, index::Integer, op::AbstractOperator)
-    _embed_lazy_check_basis(basis, basis, index, op)
-    LazyTensor(basis, index, op)
+
+"""
+    _check_subsystem(basis_l, basis_r, index, op)
+
+Verify that `op` is compatible with the subsystem at `index` in `basis_l` and
+`basis_r`. Throws `IncompatibleBases` if the bases do not match.
+"""
+function _check_subsystem(basis_l, basis_r, index, op)
+    (basis_l.bases[index] == op.basis_l && basis_r.bases[index] == op.basis_r) ||
+        throw(IncompatibleBases())
 end
 
-function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
+"""
+    _check_subsystems(basis_l, basis_r, indices, ops)
+
+Verify that each operator in `ops` is compatible with the corresponding subsystem
+in `basis_l` and `basis_r`. Also checks that `indices` and `ops` have the same
+length before iterating.
+"""
+function _check_subsystems(basis_l, basis_r, indices, ops)
+    length(indices) == length(ops) ||
+        throw(ArgumentError("length(indices) must equal length(operators)"))
+    for (i, op) in zip(indices, ops)
+        _check_subsystem(basis_l, basis_r, i, op)
+    end
+end
+
+
+"""
+    embed_lazy(basis_l, basis_r, index, op)
+    embed_lazy(basis_l, basis_r, index, op::LazyTensor)
+    embed_lazy(basis_l, basis_r, index, op::LazySum)
+    embed_lazy(basis_l, basis_r, index, op::TimeDependentSum)
+
+Single-index embedding into a `CompositeBasis`. The asymmetric `(basis_l, basis_r)`
+form. The symmetric shortcut `embed_lazy(b, index, op)` at the end delegates here 
+so there is only one place to update if the logic changes.
+
+Each operator type dispatches separately because the wrapping differs: plain operators
+go into a `LazyTensor` directly, `LazySum` maps recursively over its terms, and
+`TimeDependentSum` re-embeds only the static part while preserving the time-varying
+coefficients unchanged.
+"""
+function embed_lazy(bl::CompositeBasis, br::CompositeBasis,
                     index::Integer, op::AbstractOperator)
-    _embed_lazy_check_basis(basis_l, basis_r, index, op)
-    LazyTensor(basis_l, basis_r, index, op)
+    _check_subsystem(bl, br, index, op)
+    LazyTensor(bl, br, index, op)
 end
 
-# LazyTensor (single-index shortcut)
-
-function embed_lazy(basis::CompositeBasis, index::Integer, op::LazyTensor)
-    length(op.operators) == 1 ||
-        throw(ArgumentError("embed_lazy with a single index requires a single-operator LazyTensor."))
-    LazyTensor(basis, index, first(values(op.operators)), op.factor)
-end
-
-function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
+function embed_lazy(bl::CompositeBasis, br::CompositeBasis,
                     index::Integer, op::LazyTensor)
     length(op.operators) == 1 ||
-        throw(ArgumentError("embed_lazy with a single index requires a single-operator LazyTensor."))
-    LazyTensor(basis_l, basis_r, index, first(values(op.operators)), op.factor)
+        throw(ArgumentError("single-index embed_lazy needs a single-operator LazyTensor"))
+    LazyTensor(bl, br, index, first(values(op.operators)), op.factor)
 end
 
-# LazyTensor (multi-index)
-
-function embed_lazy(basis::CompositeBasis, indices, op::LazyTensor)
-    _embed_lazy_check_basis(basis, basis, indices, op.operators)
-    LazyTensor(basis, basis, indices, op.operators, op.factor)
-end
-
-function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
-                    indices, op::LazyTensor)
-    _embed_lazy_check_basis(basis_l, basis_r, indices, op.operators)
-    LazyTensor(basis_l, basis_r, indices, op.operators, op.factor)
-end
-
-function embed_lazy(basis::CompositeBasis, index::Integer, op::LazySum)
-    LazySum(basis, basis, op.factors,
-            map(o -> embed_lazy(basis, index, o), op.operators))
-end
-
-function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
+function embed_lazy(bl::CompositeBasis, br::CompositeBasis,
                     index::Integer, op::LazySum)
-    LazySum(basis_l, basis_r, op.factors,
-            map(o -> embed_lazy(basis_l, basis_r, index, o), op.operators))
+    LazySum(bl, br, op.factors, map(o -> embed_lazy(bl, br, index, o), op.operators))
 end
 
-function embed_lazy(basis::CompositeBasis, indices, op::LazySum)
-    LazySum(basis, basis, op.factors,
-            map(o -> embed_lazy(basis, indices, o), op.operators))
-end
-
-function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
-                    indices, op::LazySum)
-    LazySum(basis_l, basis_r, op.factors,
-            map(o -> embed_lazy(basis_l, basis_r, indices, o), op.operators))
-end
-
-function embed_lazy(basis::CompositeBasis, index::Integer, op::TimeDependentSum)
-    TimeDependentSum(QuantumOpticsBase.coefficients(op),
-                     embed_lazy(basis, index, QuantumOpticsBase.static_operator(op));
-                     init_time = current_time(op))
-end
-
-function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
+function embed_lazy(bl::CompositeBasis, br::CompositeBasis,
                     index::Integer, op::TimeDependentSum)
-    TimeDependentSum(QuantumOpticsBase.coefficients(op),
-                     embed_lazy(basis_l, basis_r, index, QuantumOpticsBase.static_operator(op));
-                     init_time = current_time(op))
+    TimeDependentSum(
+        QuantumOpticsBase.coefficients(op),
+        embed_lazy(bl, br, index, QuantumOpticsBase.static_operator(op));
+        init_time = current_time(op)
+    )
 end
 
-function embed_lazy(basis::CompositeBasis, indices, op::TimeDependentSum)
-    TimeDependentSum(QuantumOpticsBase.coefficients(op),
-                     embed_lazy(basis, indices, QuantumOpticsBase.static_operator(op));
-                     init_time = current_time(op))
+embed_lazy(b::CompositeBasis, index::Integer, op) = embed_lazy(b, b, index, op)
+
+
+"""
+    embed_lazy(basis_l, basis_r, indices, op::LazyTensor)
+    embed_lazy(basis_l, basis_r, indices, op::LazySum)
+    embed_lazy(basis_l, basis_r, indices, operators)
+
+Multi-index embedding into a `CompositeBasis`. A `LazyTensor` already carries its
+own operator dictionary, so we validate the existing operators against the new basis
+and re-wrap rather than constructing from scratch. A plain vector of operators is
+assembled into a fresh `LazyTensor`. `LazySum` recurses over its terms the same way
+as in the single-index case.
+"""
+function embed_lazy(bl::CompositeBasis, br::CompositeBasis,
+                    indices, op::LazyTensor)
+    _check_subsystems(bl, br, indices, op.operators)
+    LazyTensor(bl, br, indices, op.operators, op.factor)
 end
 
-function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
-                    indices, op::TimeDependentSum)
-    TimeDependentSum(QuantumOpticsBase.coefficients(op),
-                     embed_lazy(basis_l, basis_r, indices, QuantumOpticsBase.static_operator(op));
-                     init_time = current_time(op))
+function embed_lazy(bl::CompositeBasis, br::CompositeBasis,
+                    indices, op::LazySum)
+    LazySum(bl, br, op.factors, map(o -> embed_lazy(bl, br, indices, o), op.operators))
 end
 
-# Disambiguating method: CompositeBasis + single Integer index + vector of ops
-function embed_lazy(basis::CompositeBasis, index::Integer,
+function embed_lazy(bl::CompositeBasis, br::CompositeBasis, indices,
                     operators::AbstractVector{<:AbstractOperator})
-    length(operators) == 1 ||
-        throw(ArgumentError("embed_lazy with a single index requires a single-element operator vector."))
-    embed_lazy(basis, index, only(operators))
+    _check_subsystems(bl, br, indices, operators)
+    LazyTensor(bl, br, indices, Tuple(operators))
 end
 
-function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis, index::Integer,
-                    operators::AbstractVector{<:AbstractOperator})
-    length(operators) == 1 ||
-        throw(ArgumentError("embed_lazy with a single index requires a single-element operator vector."))
-    embed_lazy(basis_l, basis_r, index, only(operators))
-end
+embed_lazy(b::CompositeBasis, indices, op) = embed_lazy(b, b, indices, op)
 
-# Multi-index versions
-function embed_lazy(basis::CompositeBasis, indices,
-                    operators::AbstractVector{<:AbstractOperator})
-    _embed_lazy_check_basis(basis, basis, indices, operators)
-    LazyTensor(basis, basis, indices, Tuple(operators))
-end
 
-function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis, indices,
-                    operators::AbstractVector{<:AbstractOperator})
-    _embed_lazy_check_basis(basis_l, basis_r, indices, operators)
-    LazyTensor(basis_l, basis_r, indices, Tuple(operators))
-end
+"""
+    embed_lazy(b::Basis, index, op)
 
-# Non-Composite Basis (identity embed)
-
-function embed_lazy(b::Basis, index::Integer, op::AbstractOperator)
-    _embed_lazy_check_basis(b, index, op)
+When `b` is not a `CompositeBasis` there is nothing to embed into. The operator already 
+lives on the full space. We verify that `index` is 1 (the only meaningful position 
+on a non-composite basis) and return `op` unchanged.
+"""
+function embed_lazy(b::Basis, index::Integer, op)
+    index == 1 || throw(ArgumentError("index must be 1 for a non-composite basis"))
     op
 end
-
-function embed_lazy(b::Basis, index::Integer, op::LazyTensor)
-    _embed_lazy_check_basis(b, index, collect(values(op.operators)))
-    op
-end
-
-function embed_lazy(b::Basis, index::Integer, op::LazySum)
-    _embed_lazy_check_basis(b, index, op.operators)
-    op
-end
-
-function embed_lazy(b::Basis, index::Integer, op::TimeDependentSum)
-    _embed_lazy_check_basis(b, index, QuantumOpticsBase.static_operator(op))
-    TimeDependentSum(QuantumOpticsBase.coefficients(op),
-                     QuantumOpticsBase.static_operator(op);
-                     init_time = current_time(op))
-end
-
-function embed_lazy(b::Basis, index::Integer,
-                    operators::AbstractVector{<:AbstractOperator})
-    _embed_lazy_check_basis(b, index, operators)
-    operators
-end
-
-# Convenience (no-index)
-
-embed_lazy(b::Basis, op) = embed_lazy(b, 1, op)
-embed_lazy(b::CompositeBasis, op) = embed_lazy(b, 1, op)

--- a/src/embed_lazy.jl
+++ b/src/embed_lazy.jl
@@ -1,0 +1,200 @@
+# src/embed_lazy.jl
+# Lazy embedding utilities for QuantumOptics.
+#
+# embed_lazy is defined here (not in QuantumOpticsBase, which does not provide
+# this function) and is exported from the QuantumOptics module.
+
+using QuantumOpticsBase
+
+# ====================== Internal Basis Checks ======================
+
+function _embed_lazy_check_basis(basis_l::CompositeBasis, basis_r::CompositeBasis,
+                                 index::Integer, op::AbstractOperator)
+    (basis_l.bases[index] == op.basis_l && basis_r.bases[index] == op.basis_r) ||
+        throw(IncompatibleBases())
+end
+
+function _embed_lazy_check_basis(basis_l::CompositeBasis, basis_r::CompositeBasis,
+                                 indices, operators)
+    length(indices) == length(operators) ||
+        throw(ArgumentError("embed_lazy requires length(indices) == length(operators)."))
+    for (index, op) in zip(indices, operators)
+        basis_l.bases[index] == op.basis_l || throw(IncompatibleBases())
+        basis_r.bases[index] == op.basis_r || throw(IncompatibleBases())
+    end
+    return nothing
+end
+
+function _embed_lazy_check_basis(b::Basis, index::Integer, op::AbstractOperator)
+    index == 1 || throw(ArgumentError("For non-composite basis, embed index must be 1."))
+    b == op.basis_l || throw(IncompatibleBases())
+    return nothing
+end
+
+function _embed_lazy_check_basis(b::Basis, index::Integer,
+                                 ops::Union{Tuple,AbstractVector})
+    index == 1 || throw(ArgumentError("For non-composite basis, embed index must be 1."))
+    for op in ops
+        b == op.basis_l || throw(IncompatibleBases())
+    end
+    return nothing
+end
+
+# ====================== embed_lazy ======================
+
+"""
+    embed_lazy(basis, index, op)
+    embed_lazy(basis_l, basis_r, index, op)
+    embed_lazy(basis, indices, operators)
+
+Embed `op` into `basis` at position `index` (or positions `indices`) using
+lazy operators (`LazyTensor`, `LazySum`). Unlike `embed`, this avoids
+materialising the full tensor-product operator and therefore scales much better
+for large composite systems.
+
+For a non-composite `Basis` the operator is returned unchanged (after a
+compatibility check), since no embedding is needed.
+"""
+function embed_lazy end
+
+# --- AbstractOperator → LazyTensor ---
+
+function embed_lazy(basis::CompositeBasis, index::Integer, op::AbstractOperator)
+    _embed_lazy_check_basis(basis, basis, index, op)
+    LazyTensor(basis, index, op)
+end
+
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
+                    index::Integer, op::AbstractOperator)
+    _embed_lazy_check_basis(basis_l, basis_r, index, op)
+    LazyTensor(basis_l, basis_r, index, op)
+end
+
+# --- LazyTensor (single-index shortcut) ---
+
+function embed_lazy(basis::CompositeBasis, index::Integer, op::LazyTensor)
+    length(op.operators) == 1 ||
+        throw(ArgumentError("embed_lazy with a single index requires a single-operator LazyTensor."))
+    LazyTensor(basis, index, first(values(op.operators)), op.factor)
+end
+
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
+                    index::Integer, op::LazyTensor)
+    length(op.operators) == 1 ||
+        throw(ArgumentError("embed_lazy with a single index requires a single-operator LazyTensor."))
+    LazyTensor(basis_l, basis_r, index, first(values(op.operators)), op.factor)
+end
+
+# --- LazyTensor (multi-index) ---
+
+function embed_lazy(basis::CompositeBasis, indices, op::LazyTensor)
+    _embed_lazy_check_basis(basis, basis, indices, op.operators)
+    LazyTensor(basis, basis, indices, op.operators, op.factor)
+end
+
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
+                    indices, op::LazyTensor)
+    _embed_lazy_check_basis(basis_l, basis_r, indices, op.operators)
+    LazyTensor(basis_l, basis_r, indices, op.operators, op.factor)
+end
+
+# --- LazySum ---
+
+function embed_lazy(basis::CompositeBasis, index::Integer, op::LazySum)
+    LazySum(basis, basis, op.factors,
+            map(o -> embed_lazy(basis, index, o), op.operators))
+end
+
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
+                    index::Integer, op::LazySum)
+    LazySum(basis_l, basis_r, op.factors,
+            map(o -> embed_lazy(basis_l, basis_r, index, o), op.operators))
+end
+
+function embed_lazy(basis::CompositeBasis, indices, op::LazySum)
+    LazySum(basis, basis, op.factors,
+            map(o -> embed_lazy(basis, indices, o), op.operators))
+end
+
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
+                    indices, op::LazySum)
+    LazySum(basis_l, basis_r, op.factors,
+            map(o -> embed_lazy(basis_l, basis_r, indices, o), op.operators))
+end
+
+# --- TimeDependentSum ---
+
+function embed_lazy(basis::CompositeBasis, index::Integer, op::TimeDependentSum)
+    TimeDependentSum(QuantumOpticsBase.coefficients(op),
+                     embed_lazy(basis, index, QuantumOpticsBase.static_operator(op));
+                     init_time = current_time(op))
+end
+
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
+                    index::Integer, op::TimeDependentSum)
+    TimeDependentSum(QuantumOpticsBase.coefficients(op),
+                     embed_lazy(basis_l, basis_r, index, QuantumOpticsBase.static_operator(op));
+                     init_time = current_time(op))
+end
+
+function embed_lazy(basis::CompositeBasis, indices, op::TimeDependentSum)
+    TimeDependentSum(QuantumOpticsBase.coefficients(op),
+                     embed_lazy(basis, indices, QuantumOpticsBase.static_operator(op));
+                     init_time = current_time(op))
+end
+
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis,
+                    indices, op::TimeDependentSum)
+    TimeDependentSum(QuantumOpticsBase.coefficients(op),
+                     embed_lazy(basis_l, basis_r, indices, QuantumOpticsBase.static_operator(op));
+                     init_time = current_time(op))
+end
+
+# --- Vector of operators → LazyTensor ---
+
+function embed_lazy(basis::CompositeBasis, indices,
+                    operators::AbstractVector{<:AbstractOperator})
+    _embed_lazy_check_basis(basis, basis, indices, operators)
+    LazyTensor(basis, basis, indices, Tuple(operators))
+end
+
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis, indices,
+                    operators::AbstractVector{<:AbstractOperator})
+    _embed_lazy_check_basis(basis_l, basis_r, indices, operators)
+    LazyTensor(basis_l, basis_r, indices, Tuple(operators))
+end
+
+# ====================== Non-Composite Basis (identity embed) ======================
+
+function embed_lazy(b::Basis, index::Integer, op::AbstractOperator)
+    _embed_lazy_check_basis(b, index, op)
+    op
+end
+
+function embed_lazy(b::Basis, index::Integer, op::LazyTensor)
+    _embed_lazy_check_basis(b, index, collect(values(op.operators)))
+    op
+end
+
+function embed_lazy(b::Basis, index::Integer, op::LazySum)
+    _embed_lazy_check_basis(b, index, op.operators)
+    op
+end
+
+function embed_lazy(b::Basis, index::Integer, op::TimeDependentSum)
+    _embed_lazy_check_basis(b, index, QuantumOpticsBase.static_operator(op))
+    TimeDependentSum(QuantumOpticsBase.coefficients(op),
+                     QuantumOpticsBase.static_operator(op);
+                     init_time = current_time(op))
+end
+
+function embed_lazy(b::Basis, index::Integer,
+                    operators::AbstractVector{<:AbstractOperator})
+    _embed_lazy_check_basis(b, index, operators)
+    operators
+end
+
+# ====================== Convenience (no-index) ======================
+
+embed_lazy(b::Basis, op) = embed_lazy(b, 1, op)
+embed_lazy(b::CompositeBasis, op) = embed_lazy(b, 1, op)

--- a/test/test_steadystate.jl
+++ b/test/test_steadystate.jl
@@ -117,6 +117,35 @@ Ja_lazy = LazyTensor(basis, 1, sqrt(γ)*sm)
 Jc_lazy = LazyTensor(basis, 2, sqrt(κ)*destroy(fockbasis))
 Jlazy = [Ja_lazy, Jc_lazy]
 
+op_eager = embed(basis, 1, sqrt(γ) * sm)
+op_lazy = embed_lazy(basis, 1, sqrt(γ) * sm)
+psi = Ket(basis, randn(ComplexF64, length(basis)))
+
+@test op_lazy isa LazyTensor
+@test dense(op_lazy) == dense(op_eager)
+@test op_lazy * psi == op_eager * psi
+
+local_sum = LazySum(sx, 0.5 * sz)
+sum_eager = embed(basis, 1, local_sum)
+sum_lazy = embed_lazy(basis, 1, local_sum)
+
+@test sum_lazy isa LazySum
+@test dense(sum_lazy) == dense(sum_eager)
+@test sum_lazy * psi == sum_eager * psi
+
+multi_lazy = embed_lazy(basis, [1, 2], [sx, dense(sz)])
+multi_eager = embed(basis, [1, 2], [sx, dense(sz)])
+
+@test multi_lazy isa LazyTensor
+@test dense(multi_lazy) == dense(multi_eager)
+@test multi_lazy * psi == multi_eager * psi
+
+eager_alloc = @allocated embed(basis, 1, sm)
+lazy_alloc = @allocated embed_lazy(basis, 1, sm)
+@test lazy_alloc < eager_alloc
+
+@test_throws QuantumOpticsBase.IncompatibleBases embed_lazy(basis, 1, destroy(fockbasis))
+
 ρss = steadystate.iterative(Hlazy, Jlazy)
 @test tracedistance(ρss, ρt[end]) < 1e-3
 

--- a/test/test_timeevolution_tdops.jl
+++ b/test/test_timeevolution_tdops.jl
@@ -35,13 +35,15 @@ test_settime(Htup)
 H = TimeDependentSum(1.0=>H0, cos=>Hd)
 
 H_lazy = embed_lazy(b, 1, H)
-H_eager = embed(b, 1, H)
+# embed does not support TimeDependentSum; verify at a fixed time instead
+set_time!(H, 0.5)
+set_time!(H_lazy, 0.5)
 
 @test H_lazy isa TimeDependentSum
-@test dense(H_lazy) == dense(H_eager)
+@test dense(H_lazy) == dense(H)
 
 psi = basisstate(b, 1)
-@test H_lazy * psi == H_eager * psi
+@test H_lazy * psi == H * psi
 
 # function types not homogeneous
 @test timeevolution._tuplify(H) !== H

--- a/test/test_timeevolution_tdops.jl
+++ b/test/test_timeevolution_tdops.jl
@@ -34,6 +34,15 @@ test_settime(Htup)
 
 H = TimeDependentSum(1.0=>H0, cos=>Hd)
 
+H_lazy = embed_lazy(b, 1, H)
+H_eager = embed(b, 1, H)
+
+@test H_lazy isa TimeDependentSum
+@test dense(H_lazy) == dense(H_eager)
+
+psi = basisstate(b, 1)
+@test H_lazy * psi == H_eager * psi
+
 # function types not homogeneous
 @test timeevolution._tuplify(H) !== H
 


### PR DESCRIPTION
Closes #523.

### Motivation

The existing `embed` function materialises the full tensor-product operator into a dense or sparse matrix immediately. When building Hamiltonians over large composite Hilbert spaces, this forces an unnecessary and often expensive materialisation before the operator is ever applied to a state.

`embed_lazy` solves this by keeping the embedded operator in lazy form, deferring all matrix construction until the caller explicitly calls `dense` or `sparse`.

### Tests

- `test/test_timeevolution_tdops.jl` - tests `embed_lazy` in the context of `TimeDependentSum`, which has no `embed` method, confirming the fix for the original issue.

- `test/test_steadystate.jl` - confirming `embed_lazy` on a non-composite basis returns the operator unchanged.

```julia
# Single operator at one index
embed_lazy(basis::CompositeBasis, index::Int, op::AbstractOperator) -> LazyTensor

# Multiple operators at multiple indices (their product)
embed_lazy(basis::CompositeBasis, indices, operators) -> LazyTensor

# LazySum at one index — distributes embed_lazy over summands
embed_lazy(basis::CompositeBasis, index::Int, op::LazySum) -> LazySum

# Non-composite basis — identity (no embedding needed)
embed_lazy(basis, index, op) -> op
```

### Comparison with `embed`

| | `embed` | `embed_lazy` |
|---|---|---|
| Return type | `DenseOperator` / `SparseOperator` | `LazyTensor` / `LazySum` |
| Materialisation | Immediate | Deferred until dense/sparse |
| Works with `TimeDependentSum` | ✗ | ✓ |
| Memory cost at construction | O(N²) | O(subsystem size) |