### PR TITLE
Finish the in-repository documentation migration

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,8 +61,12 @@ steps:
     env:
       MPLBACKEND: Agg
     command: |
-      export PYTHON=/usr/bin/python3
-      /usr/bin/python3 -m pip install --user jupyter nbconvert nbformat matplotlib==3.8.3
+      docs_python_env="$(mktemp -d)"
+      uv venv --python /usr/bin/python3 "$${docs_python_env}"
+      uv pip install --python "$${docs_python_env}/bin/python" --requirement docs/requirements.txt
+      export PATH="$${docs_python_env}/bin:$${PATH}"
+      export PYTHON="$${docs_python_env}/bin/python"
+      export JUPYTER="$${docs_python_env}/bin/jupyter"
       export PYCALL_DEBUG_BUILD="yes"
       julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       julia --project=docs -e 'using Pkg; Pkg.instantiate(); Pkg.build("PyCall")'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ QuantumOptics.jl is a numerical framework written in Julia that makes it easy to
   - `spectralanalysis.jl` - Spectral analysis tools
 - `test/` - Comprehensive test suite
 - `benchmark/` - Performance benchmarking
+- `docs/` - Documentation sources and executable notebook examples
 
 ## Development Commands
 
@@ -36,8 +37,10 @@ julia --project=. -e "using TestItemRunner; @run_package_tests filter=ti->contai
 
 ### Building Documentation
 ```bash
-# Build documentation (handled by the main QuantumOptics.jl-documentation repository)
-# See: https://github.com/qojulia/QuantumOptics.jl-documentation
+# Install the Python dependencies as shown in the Docs step of .buildkite/pipeline.yml,
+# then build the documentation from the repository root.
+julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.build("PyCall")'
+julia -tauto --project=docs docs/make.jl
 ```
 
 ### Package Management

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ More information, documentation and examples can be found on our website http://
 
 ## Project Structure
 
-The source content associated with **QuantumOptics.jl** is distributed over several repositories under the [qojulia] organization on GitHub:
+The source content associated with **QuantumOptics.jl** is maintained in this repository and related repositories under the [qojulia] organization on GitHub:
 
 * The main code: https://github.com/qojulia/QuantumOptics.jl
-* Documentation: https://github.com/qojulia/QuantumOptics.jl-documentation
-* Examples: https://github.com/qojulia/QuantumOptics.jl-examples
+* Documentation: https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/src
+* Examples: https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples
 * Benchmarks: https://github.com/qojulia/QuantumOptics.jl-benchmarks
 * Website: https://github.com/qojulia/QuantumOptics.jl-website
 

--- a/docs/examples/markdown_template.tpl
+++ b/docs/examples/markdown_template.tpl
@@ -1,5 +1,11 @@
 {% extends 'markdown/index.md.j2'%}
 
+{% block body_header %}
+```@meta
+EditURL = "../../examples/notebooks/{{ resources.metadata.name }}.ipynb"
+```
+{% endblock body_header %}
+
 {% block input %}
 {%- set text = cell.source| replace("\nshow()", "") %}
 {%- if text %}

--- a/docs/examples/notebooks/atom-dephasing.ipynb
+++ b/docs/examples/notebooks/atom-dephasing.ipynb
@@ -151,7 +151,7 @@
     "Plotting, we see that both results are in very good agreement. The deviation between the two approaches stems from two sources:\n",
     "\n",
     "- The result of the master equation would correspond to the average over infinitely many trajectories.\n",
-    "- The default absolute and relative error tolerances of the solver algorithm are `abstol=1e-3` and `reltol=1e-3`, respectively. This causes deviations at longer times which can be reduced by reducing the values of `abstol` and `reltol` sacrificing on the speed of the calculation. For details on step size control, please see the **DifferentialEquations.jl** documentation [here](http://docs.juliadiffeq.org/stable/)."
+    "- The default absolute and relative error tolerances of the solver algorithm are `abstol=1e-3` and `reltol=1e-3`, respectively. This causes deviations at longer times which can be reduced by reducing the values of `abstol` and `reltol` sacrificing on the speed of the calculation. For details on step size control, please see the **DifferentialEquations.jl** documentation [here](https://docs.sciml.ai/DiffEqDocs/stable/)."
    ]
   },
   {

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -116,4 +116,5 @@ deploydocs(
     devbranch = "master",
     deploy_config = Documenter.Buildkite(),
     push_preview = true,
+    versions = nothing,
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -102,7 +102,10 @@ makedocs(
     modules = doc_modules,
     pages = pages,
     format = Documenter.HTML(
-        assets = anythingllm_assets,
+        assets = [
+            asset("assets/favicon.png", class = :ico, islocal = true),
+            anythingllm_assets...,
+        ],
         canonical = "https://docs.qojulia.org/",
         size_threshold = 400 * 2^10,
         size_threshold_warn = 300 * 2^10,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -30,6 +30,7 @@ pages = [
         "quantumobjects/bases.md",
         "quantumobjects/states.md",
         "quantumobjects/operators.md",
+        "quantumobjects/superoperators.md",
     ],
     "Quantum systems" => [
         "Introduction" => "quantumsystems/quantumsystems.md",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+jupyter==1.1.1
+matplotlib==3.8.3
+nbconvert==7.17.1
+nbformat==5.10.4

--- a/docs/src/stochastic/schroedinger.md
+++ b/docs/src/stochastic/schroedinger.md
@@ -66,7 +66,7 @@ stochastic.schroedinger(tspan, ψ0, H, Hs; dt=dt, callback=ncb)
 nothing # hide
 ```
 
-is the same as setting `normalize_state=true`. See also **DifferentialEquations.jl's** [callback library](http://docs.juliadiffeq.org/latest/features/callback_library.html#FunctionCallingCallback-1).
+is the same as setting `normalize_state=true`. See also **DifferentialEquations.jl's** [callback library](https://docs.sciml.ai/DiffEqDocs/stable/features/callback_library/).
 
 
 ## [Detection schemes with the stochastic Schrödinger equation ](@id schroedinger-homodyne)

--- a/docs/src/stochastic/semiclassical.md
+++ b/docs/src/stochastic/semiclassical.md
@@ -120,7 +120,7 @@ nothing # hide
 
 Note, that the above can be combined with the quantum noise function from before (without any further changes) by passing the corresponding function. The entire discussion above can be used in the same fashion for stochastic master equations.
 
-For details on non-diagonal noise, please refer to the **DifferentialEquations** [documentation](http://docs.juliadiffeq.org/stable/).
+For details on non-diagonal noise, please refer to the **DifferentialEquations** [documentation](https://docs.sciml.ai/DiffEqDocs/stable/).
 
 
 ## [Functions](@id stochastic-semiclassical: Functions)

--- a/docs/src/stochastic/stochastic.md
+++ b/docs/src/stochastic/stochastic.md
@@ -24,7 +24,7 @@ Note, that we need to set the keyword `dt` here, since the default algorithm is 
 
 The default algorithm is a basic **Euler-Maruyama** method with fixed step size. This choice has been made, since this algorithm is versatile yet easy to understand. Note, that this means that by default, stochastic problems are solved in the **Ito** sense.
 
-To override the default algorithm, simply set the `alg` keyword argument with one of the solvers you found [here](http://docs.juliadiffeq.org/stable/solvers/sde_solve.html#Full-List-of-Methods-1), e.g.
+To override the default algorithm, simply set the `alg` keyword argument with one of the solvers you found [here](https://docs.sciml.ai/DiffEqDocs/stable/solvers/sde_solve/#Full-List-of-Methods), e.g.
 
 ```@example stochastic-intro
 import StochasticDiffEq # hide
@@ -43,4 +43,4 @@ nothing # hide
 
 corresponds to the default for a single noise term in the Schrödinger equation. Note, that the default is complex noise for semiclassical stochastic equations, where only classical noise is included (for details see [stochastic semiclassical systems](@ref stochastic-semiclassical))
 
-For details on the available algorithms and further control over the solvers, we refer to the [documentation](http://docs.juliadiffeq.org/stable/) of [**DifferentialEquations.jl**](https://github.com/SciML/DifferentialEquations.jl).
+For details on the available algorithms and further control over the solvers, we refer to the [documentation](https://docs.sciml.ai/DiffEqDocs/stable/) of [**DifferentialEquations.jl**](https://github.com/SciML/DifferentialEquations.jl).

--- a/docs/src/timeevolution/timeevolution.md
+++ b/docs/src/timeevolution/timeevolution.md
@@ -1,7 +1,7 @@
 # Time-evolution
 
 
-**QuantumOptics.jl** implements various solvers to simulate the dynamics of closed as well as open quantum systems. The interfaces are designed to be as consistent as possible which makes it easy to switch between different methods. Internally, all of them rely on [**DifferentialEquations.jl**](https://github.com/SciML/), which is a very rich numerical library for the solution of differential equations. It offers quite a few options for the user to tailor the solver to their specific needs. The defaults are chosen for to suit commonly encountered problems and should work fine for most use cases. If you require more specialized methods, such as the choice of algorithm, please refer to the documentation of **DifferentialEquations.jl**, which can be found [here](http://docs.juliadiffeq.org/stable/).
+**QuantumOptics.jl** implements various solvers to simulate the dynamics of closed as well as open quantum systems. The interfaces are designed to be as consistent as possible which makes it easy to switch between different methods. Internally, all of them rely on [**DifferentialEquations.jl**](https://github.com/SciML/), which is a very rich numerical library for the solution of differential equations. It offers quite a few options for the user to tailor the solver to their specific needs. The defaults are chosen for to suit commonly encountered problems and should work fine for most use cases. If you require more specialized methods, such as the choice of algorithm, please refer to the documentation of **DifferentialEquations.jl**, which can be found [here](https://docs.sciml.ai/DiffEqDocs/stable/).
 
 ```@example
 using QuantumOptics # hide


### PR DESCRIPTION
## Summary

- publish documentation directly at the Pages root with `versions = nothing`
- point generated example edit links to their source notebooks
- restore the favicon and add Superoperators to navigation
- replace obsolete DifferentialEquations links with current SciML documentation
- use an isolated `uv` environment with exact direct package pins
- update README and contributor guidance for the in-repository documentation layout

The one-time generated-branch cleanup is in #537. It removes the obsolete Sphinx tree and only previews for closed PRs, without adding a cleanup workflow. A separate PR is required because those files exist only on `gh-pages`.

## Commit structure

Each concern is a separate commit:

1. root deployment
2. notebook edit links
3. favicon
4. Superoperators navigation
5. SciML links
6. pinned `uv` environment
7. repository guidance

## Validation

- full documentation build with Julia 1.12.6 and Python 3.10.14
- all 22 notebooks executed successfully
- 52 documentation pages rendered
- 22 notebook edit links rendered; zero links to generated Markdown
- favicon link present on all 52 pages
- Superoperators present in navigation
- no remaining `docs.juliadiffeq.org` references
- current SciML targets and the SDE-method anchor return HTTP 200
- Buildkite YAML parsed successfully
- `git diff --check`

The package test suite was not run because this PR changes only documentation sources and its build environment; the full documentation integration build was used instead.