### PR TITLE
Precompile representative usage workloads

### DIFF
--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -18,9 +18,6 @@ concurrency:
 
 jobs:
   compare:
-    # The setup PR adds PrecompileTools, while the benchmark requires identical
-    # dependency metadata. The first workload PR removes this bootstrap guard.
-    if: ${{ false }}
     name: Compare base and head
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,1 +1,35 @@
 using PrecompileTools
+
+@setup_workload let
+    # Closed-system, open-system, and quantum-trajectory time evolution
+    basis = FockBasis(4)
+    hamiltonian = number(basis)
+    jumps = [destroy(basis)]
+    initial_state = fockstate(basis, 1)
+    times = [0.0, 0.1]
+
+    @compile_workload begin
+        schroedinger_times, pure_states =
+            timeevolution.schroedinger(times, initial_state, hamiltonian)
+        @assert schroedinger_times == times
+        @assert isapprox(norm(pure_states[end]), 1; atol=1e-9)
+        @assert isfinite(real(expect(hamiltonian, pure_states[end])))
+
+        master_times, density_states =
+            timeevolution.master(times, initial_state, hamiltonian, jumps)
+        @assert master_times == times
+        @assert isapprox(tr(density_states[end]), 1; atol=1e-10)
+        @assert isfinite(real(expect(hamiltonian, density_states[end])))
+
+        mcwf_times, trajectory_states = timeevolution.mcwf(
+            times,
+            initial_state,
+            hamiltonian,
+            jumps;
+            seed=UInt(0),
+        )
+        @assert mcwf_times == times
+        @assert isapprox(norm(trajectory_states[end]), 1; atol=1e-10)
+        @assert isfinite(real(expect(hamiltonian, trajectory_states[end])))
+    end
+end


### PR DESCRIPTION
## Stack

#539 is merged. This branch is rebased directly onto its squash-merge commit, `731a655`; the incremental diff is only the representative workload and removal of the one-time CI bootstrap guard.

## Summary

- add a deterministic `PrecompileTools` workload for the three core public time-evolution APIs
- cover closed-system Schrödinger evolution, open-system master evolution, and a fixed-seed MCWF trajectory
- use the concrete Fock-space flow from the canonical time-evolution documentation
- remove the bootstrap guard so the latency workflow is byte-identical to the current QuantumOpticsBase.jl workflow

The workload follows `docs/src/timeevolution/timeevolution.md`; the excited Fock state makes the dissipative paths nontrivial. Steady-state and correlation remain outside this example workload so the follow-up trace stage can measure residual compilation.

## Latency result

A reportable local v3 comparison against #539 used Julia 1.12.6, five independent cache builds, four recorded fresh-process samples per scenario and build, counterbalanced base/head order, one reused consumer environment, and QuantumOpticsBase master `a888b5a`.

| Scenario | First call before | First call after | Change | Total cold latency change |
|---|---:|---:|---:|---:|
| Schrödinger | 2,558 ms | 54 ms | -97.9% | -58.7% |
| Master | 3,274 ms | 370 ms | -88.7% | -58.3% |
| MCWF | 4,114 ms | 345 ms | -91.6% | -64.8% |
| Steady state | 1,413 ms | 1,421 ms | +0.6% | +1.5% |
| Correlation | 3,305 ms | 1,479 ms | -55.2% | -36.3% |

Schrödinger, master, MCWF, and correlation improved materially in all five builds. Steady-state had no material change. Median package-cache construction increased from 5.22 s to 10.50 s, cache size from 1.48 MiB to 15.60 MiB, and import latency by 30 to 33 ms depending on the scenario.

## Validation

- full `Pkg.test()` on the current stack with Julia 1.12.6 and QuantumOpticsBase master: 2,642 passed, 1 expected broken
- `Pkg.precompile()` and package import on Julia 1.10.12 and 1.12.6 with QuantumOpticsBase master
- import with `--compiled-modules=no` on Julia 1.12.6
- all five scenarios in fresh processes on Julia 1.10.12 and 1.12.6
- reportable centralized v3 comparison: five builds, four samples, all expected raw and summary artifacts
- hosted benchmark, downgrade, Linux, macOS, Windows, and coverage checks pass
- `git diff --check`
