### PR TITLE
Add trace-derived precompile statements

### DIFF
--- a/src/QuantumOptics.jl
+++ b/src/QuantumOptics.jl
@@ -50,5 +50,6 @@ end
 using .timeevolution
 
 include("precompile.jl")
+include("precompile_statements.jl")
 
 end # module

--- a/src/precompile_statements.jl
+++ b/src/precompile_statements.jl
@@ -1,0 +1,14 @@
+# Generated from the cold-start scenarios on Julia 1.12.6 (x86_64-linux-gnu).
+# Each raw trace was filtered with sortprecompile.py revision
+# 4ea3c813d9a5adc494d84368e08825f5d765a0a6 using `-m 50.000001`.
+# Timing comments preserve the largest observation for each exact statement.
+# Recompilations and signatures tied to scenarios, the benchmark driver,
+# package artifacts, generated names, private Base methods, compiler or solver
+# internals, or modules not bound in QuantumOptics are excluded. These
+# observations select statements; they are not benchmarks.
+
+using PrecompileTools: @setup_workload
+
+@setup_workload begin
+    #=   51.9 ms =# precompile(Tuple{typeof(Core.kwcall), NamedTuple{(:alg, :by), Tuple{Base.Sort.QuickSortAlg, typeof(LinearAlgebra.eigsortby)}}, typeof(Base.sortperm), Array{Base.Complex{Float64}, 1}})
+end


### PR DESCRIPTION
## Stack

#539 and #540 are merged. Before this PR was merged, its branch was rebased directly onto squash-merge commit `9de700c` from #540; the incremental diff was only the trace-derived statement file and its module include.

## Summary

- add one explicit precompile directive selected from residual Julia 1.12.6 compilation traces
- keep the generated statement in `src/precompile_statements.jl`, loaded after the representative workload
- retain timing and filter provenance while excluding unstable or irrelevant signatures

This follows the trace-derived stage used by QuantumOpticsBase.jl. The retained tuple uses implementation-level Core and Base names, so its compatibility was checked explicitly on Julia 1.10.12 and 1.12.6.

## Trace generation and filtering

The reported traces were generated from the #540 workload tree (`9e58681`) after building its package cache in a fresh, dedicated depot. QuantumOpticsBase was path-pinned to the then-current and still-current master commit `a888b5a`.

Each of the five cold-start scenarios ran in a separate single-threaded Julia 1.12.6 process with no competing Julia process and with:

```text
--trace-compile=PATH --trace-compile-timing
```

The run produced 284 timed raw lines. Each file was filtered with [sortprecompile.py](https://gist.github.com/KristofferC/f9abc44418f9474baa0d30b1c3e764d4) by Kristoffer Carlsson, pinned at revision `4ea3c813d9a5adc494d84368e08825f5d765a0a6` (raw SHA-256 `2ca2fb16cab2c166442f7cb501afaa597b1992b3d77420d3e96903206d9c08a4`):

```text
-m 50.000001
```

The epsilon is intentional because the filter keeps observations greater than or equal to its threshold; this selects strictly longer than 50 ms.

Filtering produced 12 observations and 8 exact unique statements. One portable statement remains after excluding five scenario-local `Main` entry points, five benchmark-driver argument-handling observations, and one deeply parameterized solver specialization tied to generated QuantumOptics closures. No recompilation exceeded the cutoff.

The retained `sortperm` signature took 51.9 ms in the latest-master steady-state trace. It also exceeded 50 ms in two prior independent traces. A private `Base.PermutedDimsArrays._copy!` signature exceeded 50 ms only in the first trace, fell below the cutoff in an audit trace, and did not exceed the cutoff in the latest-master trace, so it is not committed. The retained statement returns `true` inside QuantumOptics on Julia 1.10.12 and 1.12.6.

## Latency result

A reportable local v3 comparison against #540 used five independent cache builds, four recorded fresh-process samples per scenario and build, counterbalanced base/head order, one reused consumer environment, and QuantumOpticsBase master `a888b5a`.

The trace directive reduced steady-state first-call latency from 1,415 ms to 1,348 ms (-66.7 ms, -4.7%) and total cold latency from 3,099 ms to 3,034 ms (-65.0 ms, -2.1%). All five builds improved by 60.3 to 80.4 ms, but this remained below the harness's material threshold of about 155 ms. Other scenarios changed by at most 2 ms in their median total latency.

Median package-cache construction changed from 10.50 s to 10.54 s (+0.03 s, +0.3%), and cache size from 15.59 MiB to 15.71 MiB (+0.12 MiB, +0.7%). This limited result is stated explicitly so review can distinguish trace selection from a formally material benchmark gain.

## Validation

- rebased tree verified byte-identical to the previously validated head
- full `Pkg.test()` on Julia 1.12.6 with QuantumOpticsBase master: 2,642 passed, 1 expected broken
- `Pkg.precompile()` and package import on Julia 1.10.12 and 1.12.6 with QuantumOpticsBase master
- import with `--compiled-modules=no` on Julia 1.12.6
- all five scenarios in fresh Julia 1.10.12 and 1.12.6 processes
- `Pkg.precompile()` and all five scenarios on Julia 1.10.12 with registered QuantumOpticsBase 0.5.11
- reportable centralized v3 comparison: five builds, four samples, all expected raw and summary artifacts
- trace regeneration against QuantumOpticsBase master: 284 raw observations, 12 strict `>50 ms`, 8 exact unique statements
- Julia syntax, whitespace, and diff checks


