### PR TITLE
Reduce load invalidations from WignerSymbols

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
-WignerSymbols = "9f57e263-0b3d-5e2e-b1be-24f2bb48858b"
 
 [compat]
 Arpack = "0.5.1 - 0.5.3"
@@ -40,5 +39,4 @@ Reexport = "1.2.2"
 SciMLBase = "3.1"
 SparseArrays = "1.10"
 StochasticDiffEq = "7"
-WignerSymbols = "1, 2"
 julia = "1.10"

--- a/src/phasespace.jl
+++ b/src/phasespace.jl
@@ -1,4 +1,3 @@
-import WignerSymbols: clebschgordan
 import QuantumOpticsBase:
     qfunc,
     wigner,
@@ -368,6 +367,24 @@ function qfuncsu2(rho::Operator{B,B}, theta::Real, phi::Real) where B<:SpinBasis
     return result
 end
 
+# Closed form for ⟨1,q; S,M-q | S+1,M⟩.
+function _clebschgordan_1(q::Integer, S::Integer, M::Integer, ::Type{T}) where {T<:Real}
+    if q == 0
+        numerator = (S + 1)^2 - M^2
+        denominator = (S + 1) * (2S + 1)
+    elseif q == 1
+        numerator = (S + M) * (S + M + 1)
+        denominator = 2 * (S + 1) * (2S + 1)
+    elseif q == -1
+        numerator = (S - M) * (S - M + 1)
+        denominator = 2 * (S + 1) * (2S + 1)
+    else
+        throw(ArgumentError("q must be -1, 0, or 1"))
+    end
+    W = promote_type(T, Float32)
+    return T(sqrt(W(numerator) / W(denominator)))
+end
+
 """
     wignersu2(ket,Ntheta;Nphi=2Ntheta)
     wignersu2(rho,Ntheta;Nphi=2Ntheta)
@@ -386,29 +403,30 @@ This version calculates the Wigner SU(2) function at a position given by θ and 
 function wignersu2(rho::Operator{B,B}, theta::Real, phi::Real) where B<:SpinBasis
 
     N = length(basis(rho))-1
+    T = real(eltype(rho))
 
     ### Tensor generation ###
-    BandT = Array{Vector{real(eltype(rho))}}(undef, N,N+1)
+    BandT = Array{Vector{T}}(undef, N,N+1)
     BandT[1,1] = collect(range(-N/2, stop=N/2, length=N+1))
     BandT[1,2] = -collect(sqrt.(range(1, stop=N, length=N)).*sqrt.(range((N)/2, stop=1/2, length=N)))
-    BandT[2,1] = clebschgordan(1,0,1,0,2,0)*BandT[1,1].*BandT[1,1] -
-        clebschgordan(1,-1,1,1,2,0)*[zeros(N+1-length(BandT[1,2])); BandT[1,2].*BandT[1,2]] -
-        clebschgordan(1,1,1,-1,2,0)*[BandT[1,2].*BandT[1,2]; zeros(N+1-length(BandT[1,2]))]
-    BandT[2,2] = clebschgordan(1,0,1,1,2,1)BandT[1,1][1:N].*BandT[1,2]+
-        clebschgordan(1,1,1,0,2,1)*BandT[1,2][1:N].*BandT[1,1][2:end]
+    BandT[2,1] = _clebschgordan_1(0,1,0,T)*BandT[1,1].*BandT[1,1] -
+        _clebschgordan_1(-1,1,0,T)*[zeros(N+1-length(BandT[1,2])); BandT[1,2].*BandT[1,2]] -
+        _clebschgordan_1(1,1,0,T)*[BandT[1,2].*BandT[1,2]; zeros(N+1-length(BandT[1,2]))]
+    BandT[2,2] = _clebschgordan_1(0,1,1,T)BandT[1,1][1:N].*BandT[1,2]+
+        _clebschgordan_1(1,1,1,T)*BandT[1,2][1:N].*BandT[1,1][2:end]
     BandT[2,3] = BandT[1,2][1:N+1-(2)].*BandT[1,2][2:end]
 
     @inbounds for S=2:N-1
-        BandT[S+1,1] = clebschgordan(1,0,S,0,S+1,0)*BandT[1,1].*BandT[S,1] -
-            [zeros(N+1-length(BandT[1,2])); clebschgordan(1,-1,S,1,S+1,0)*BandT[1,2].*BandT[S,2]] -
-            clebschgordan(1,1,S,-1,S+1,0)*[BandT[1,2].*BandT[S,2]; zeros(N+1-length(BandT[1,2]))]
-        BandT[S+1,S+1] = clebschgordan(1,0,S,S,S+1,S)BandT[1,1][1:N+1-S].*BandT[S,S+1]+
-            clebschgordan(1,1,S,S-1,S+1,S)*BandT[1,2][1:N+1-S].*BandT[S,S][2:end]
+        BandT[S+1,1] = _clebschgordan_1(0,S,0,T)*BandT[1,1].*BandT[S,1] -
+            [zeros(N+1-length(BandT[1,2])); _clebschgordan_1(-1,S,0,T)*BandT[1,2].*BandT[S,2]] -
+            _clebschgordan_1(1,S,0,T)*[BandT[1,2].*BandT[S,2]; zeros(N+1-length(BandT[1,2]))]
+        BandT[S+1,S+1] = _clebschgordan_1(0,S,S,T)BandT[1,1][1:N+1-S].*BandT[S,S+1]+
+            _clebschgordan_1(1,S,S,T)*BandT[1,2][1:N+1-S].*BandT[S,S][2:end]
         BandT[S+1,S+2] = BandT[1,2][1:N+1-(S+1)].*BandT[S,S+1][2:end]
         @inbounds for M=1:S-1
-            BandT[S+1,M+1] = clebschgordan(1, 0, S, M, S+1,M)*BandT[1,1][1:N+1-M].*BandT[S,M+1] +
-                clebschgordan(1,1,S,M-1,S+1,M)*BandT[1,2][1:N+1-M].*BandT[S,M][2:end] -
-                clebschgordan(1,-1,S,M+1,S+1,M)*[zeros(1); BandT[1,2][1:N-M].*BandT[S,M+2][1:N-M]]
+            BandT[S+1,M+1] = _clebschgordan_1(0,S,M,T)*BandT[1,1][1:N+1-M].*BandT[S,M+1] +
+                _clebschgordan_1(1,S,M,T)*BandT[1,2][1:N+1-M].*BandT[S,M][2:end] -
+                _clebschgordan_1(-1,S,M,T)*[zeros(1); BandT[1,2][1:N-M].*BandT[S,M+2][1:N-M]]
         end
 
     end
@@ -436,29 +454,30 @@ end
 function wignersu2(rho::Operator{B,B}, Ntheta::Integer; Nphi::Integer=2Ntheta) where B<:SpinBasis
 
     N = length(basis(rho))-1
+    T = real(eltype(rho))
 
     ### Tensor generation ###
-    BandT = Array{Vector{real(eltype(rho))}}(undef, N,N+1)
+    BandT = Array{Vector{T}}(undef, N,N+1)
     BandT[1,1] = collect(range(-N/2, stop=N/2, length=N+1))
     BandT[1,2] = -collect(sqrt.(range(1, stop=N, length=N)).*sqrt.(range((N)/2, stop=1/2, length=N)))
-    BandT[2,1] = clebschgordan(1,0,1,0,2,0)*BandT[1,1].*BandT[1,1] -
-        clebschgordan(1,-1,1,1,2,0)*[zeros(N+1-length(BandT[1,2])); BandT[1,2].*BandT[1,2]] -
-        clebschgordan(1,1,1,-1,2,0)*[BandT[1,2].*BandT[1,2]; zeros(N+1-length(BandT[1,2]))]
-    BandT[2,2] = clebschgordan(1,0,1,1,2,1)BandT[1,1][1:N].*BandT[1,2]+
-        clebschgordan(1,1,1,0,2,1)*BandT[1,2][1:N].*BandT[1,1][2:end]
+    BandT[2,1] = _clebschgordan_1(0,1,0,T)*BandT[1,1].*BandT[1,1] -
+        _clebschgordan_1(-1,1,0,T)*[zeros(N+1-length(BandT[1,2])); BandT[1,2].*BandT[1,2]] -
+        _clebschgordan_1(1,1,0,T)*[BandT[1,2].*BandT[1,2]; zeros(N+1-length(BandT[1,2]))]
+    BandT[2,2] = _clebschgordan_1(0,1,1,T)BandT[1,1][1:N].*BandT[1,2]+
+        _clebschgordan_1(1,1,1,T)*BandT[1,2][1:N].*BandT[1,1][2:end]
     BandT[2,3] = BandT[1,2][1:N+1-(2)].*BandT[1,2][2:end]
 
     @inbounds for S=2:N-1
-        BandT[S+1,1] = clebschgordan(1,0,S,0,S+1,0)*BandT[1,1].*BandT[S,1] -
-            [zeros(N+1-length(BandT[1,2])); clebschgordan(1,-1,S,1,S+1,0)*BandT[1,2].*BandT[S,2]] -
-            clebschgordan(1,1,S,-1,S+1,0)*[BandT[1,2].*BandT[S,2]; zeros(N+1-length(BandT[1,2]))]
-        BandT[S+1,S+1] = clebschgordan(1,0,S,S,S+1,S)BandT[1,1][1:N+1-S].*BandT[S,S+1]+
-            clebschgordan(1,1,S,S-1,S+1,S)*BandT[1,2][1:N+1-S].*BandT[S,S][2:end]
+        BandT[S+1,1] = _clebschgordan_1(0,S,0,T)*BandT[1,1].*BandT[S,1] -
+            [zeros(N+1-length(BandT[1,2])); _clebschgordan_1(-1,S,0,T)*BandT[1,2].*BandT[S,2]] -
+            _clebschgordan_1(1,S,0,T)*[BandT[1,2].*BandT[S,2]; zeros(N+1-length(BandT[1,2]))]
+        BandT[S+1,S+1] = _clebschgordan_1(0,S,S,T)BandT[1,1][1:N+1-S].*BandT[S,S+1]+
+            _clebschgordan_1(1,S,S,T)*BandT[1,2][1:N+1-S].*BandT[S,S][2:end]
         BandT[S+1,S+2] = BandT[1,2][1:N+1-(S+1)].*BandT[S,S+1][2:end]
         @inbounds for M=1:S-1
-            BandT[S+1,M+1] = clebschgordan(1, 0, S, M, S+1,M)*BandT[1,1][1:N+1-M].*BandT[S,M+1] +
-                clebschgordan(1,1,S,M-1,S+1,M)*BandT[1,2][1:N+1-M].*BandT[S,M][2:end] -
-                clebschgordan(1,-1,S,M+1,S+1,M)*[0.0im; BandT[1,2][1:N-M].*BandT[S,M+2][1:N-M]]
+            BandT[S+1,M+1] = _clebschgordan_1(0,S,M,T)*BandT[1,1][1:N+1-M].*BandT[S,M+1] +
+                _clebschgordan_1(1,S,M,T)*BandT[1,2][1:N+1-M].*BandT[S,M][2:end] -
+                _clebschgordan_1(-1,S,M,T)*[0.0im; BandT[1,2][1:N-M].*BandT[S,M+2][1:N-M]]
         end
     end
 

--- a/test/test_phasespace.jl
+++ b/test/test_phasespace.jl
@@ -169,6 +169,34 @@ qsu2dm = sum(qfuncsu2(dmrs,res).*costhetam)*(π/res)^2
 @test isapprox(wsu2, 1.0, atol=1e-2)
 @test isapprox(wsu2dm, 1.0, atol=1e-2)
 
+@testset "SU(2) Wigner rotation covariance" begin
+    basis = SpinBasis(2)
+    data = ComplexF64[1 + im, 2 - im, -1 + 2im, 3, 2 + im]
+    normalize!(data)
+    state = dm(Ket(basis, data))
+
+    beta = 0.37
+    theta = 1.1
+    phi = -0.8
+    rotation = exp(-0.5im * beta * dense(sigmay(basis)))
+    rotated_state = rotation * state * dagger(rotation)
+
+    x = sin(theta) * cos(phi)
+    y = sin(theta) * sin(phi)
+    z = cos(theta)
+    rotated_x = cos(beta) * x + sin(beta) * z
+    rotated_y = y
+    rotated_z = -sin(beta) * x + cos(beta) * z
+    rotated_theta = acos(clamp(rotated_z, -1, 1))
+    rotated_phi = atan(rotated_y, rotated_x)
+
+    @test isapprox(
+        wignersu2(rotated_state, theta, phi),
+        wignersu2(state, rotated_theta, rotated_phi);
+        atol=1e-12,
+    )
+end
+
 
 # Test CSS for large spin number (#326)
 b = SpinBasis(35)  # S=35 overflows `binomial` function, e.g. binomial(70, 26)


### PR DESCRIPTION
## Summary

- replace the restricted Clebsch-Gordan calls used by `wignersu2` with their closed forms
- remove the direct WignerSymbols dependency and its transitive load chain
- add a deterministic SU(2) Wigner rotation-covariance regression test

## Invalidation results

Captured with Julia 1.12.6, SnoopCompile 3.2.7, SnoopCompileCore 3.1.2, and QuantumOpticsBase master `a888b5a47b4dda3c16971d4f487057b39b9be575`.

| Scenario | Baseline unique invalidated MIs | Candidate | Baseline tree nodes | Candidate |
|---|---:|---:|---:|---:|
| QuantumOpticsBase preloaded | 829 | 700 | 10,660 | 9,814 |
| Full QuantumOptics load | 1,517 | 1,401 | 11,728 | 10,881 |

This is a net 15.6% reduction in unique invalidated method instances for the isolated QuantumOptics load and 7.6% for the full load. QuantumOptics itself caused no invalidation trees and had no victim nodes. The remaining six QuantumOpticsBase-owned trees are unchanged and much smaller; the dominant remaining causes belong to external dependencies.

Seven interleaved fresh-process import samples showed a host-local median change from 1.635 s to 1.622 s, or 0.76%. This timing is supporting evidence rather than a general latency guarantee.

## Validation

- `Pkg.test("QuantumOptics"; allow_reresolve=false)`: 2,643 passed, one pre-existing broken test
- direct TestItemRunner invocation: 5,481 checks passed
- closed-form coefficients matched WignerSymbols for Float16, Float32, Float64, and BigFloat
- repeated post-commit invalidation tree rankings were byte-identical
- full suite and captures used the latest QuantumOpticsBase master through a local path

Julia 1.10 and GPU tests were not run locally because those runtimes were not available.

Compatibility note: this removes the undocumented and unexported `QuantumOptics.clebschgordan` binding.