### PR TITLE
Make steady-state eigenvectors inferable

### DIFF
--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -29,6 +29,14 @@ function master(H::AbstractOperator, J;
                         tol = tol, kwargs...)
 end
 
+function _eigenoperators(L, vectors, indices)
+    dims = (length(L.basis_r[1]), length(L.basis_r[2]))
+    return [
+        DenseOperator(L.basis_r[1], L.basis_r[2], reshape(vectors[:, i], dims))
+        for i in indices
+    ]
+end
+
 """
     steadystate.liouvillianspectrum(L)
     steadystate.liouvillianspectrum(H, J)
@@ -45,12 +53,7 @@ sorted according to the absolute value of the eigenvalues.
 function liouvillianspectrum(L::DenseSuperOpType; nev::Int = min(10, length(L.basis_r[1])*length(L.basis_r[2])), which::Symbol = :LR, kwargs...)
     d, v = eigen(L.data; kwargs...)
     indices = sortperm(abs.(d))[1:nev]
-    ops = DenseOpType[]
-    for i in indices
-        data = reshape(v[:,i], length(L.basis_r[1]), length(L.basis_r[2]))
-        op = DenseOperator(L.basis_r[1], L.basis_r[2], data)
-        push!(ops, op)
-    end
+    ops = _eigenoperators(L, v, indices)
     return d[indices], ops
 end
 
@@ -64,13 +67,10 @@ function liouvillianspectrum(L::SparseSuperOpType; nev::Int = min(10, length(L.b
             rethrow(err)
         end
     end
+    # Arpack does not infer the eigenvector matrix type.
+    v = v::Matrix{eltype(d)}
     indices = sortperm(abs.(d))[1:nev]
-    ops = DenseOpType[]
-    for i in indices
-        data = reshape(v[:,i], length(L.basis_r[1]), length(L.basis_r[2]))
-        op = DenseOperator(L.basis_r[1], L.basis_r[2], data)
-        push!(ops, op)
-    end
+    ops = _eigenoperators(L, v, indices)
     return d[indices], ops
 end
 

--- a/test/test_steadystate.jl
+++ b/test/test_steadystate.jl
@@ -61,10 +61,10 @@ tss, ρss = steadystate.master(Hdense, Jdense; tol=1e-4)
 ρss = steadystate.eigenvector(H, sqrt(2).*J; rates=0.5.*ones(length(J)), tol=1e-8)
 @test tracedistance(ρss, ρt[end]) < 1e-3
 
-ρss = steadystate.eigenvector(H, sqrt(2).*J; rates=0.5.*ones(length(J)), nev = 1)
+ρss = @inferred steadystate.eigenvector(H, sqrt(2).*J; rates=0.5.*ones(length(J)), nev = 1)
 @test tracedistance(ρss, ρt[end]) < 1e-3
 
-ρss = steadystate.eigenvector(liouvillian(Hdense, Jdense))
+ρss = @inferred steadystate.eigenvector(liouvillian(Hdense, Jdense))
 @test tracedistance(ρss, ρt[end]) < 1e-6
 
 @test_throws TypeError steadystate.eigenvector(H, J; ncv="a")
@@ -72,10 +72,12 @@ tss, ρss = steadystate.master(Hdense, Jdense; tol=1e-4)
 ev, ops = steadystate.liouvillianspectrum(Hdense, Jdense)
 @test tracedistance(ρss, ops[1]) < 1e-12
 @test ev[sortperm(abs.(ev))] == ev
+@test isconcretetype(eltype(ops))
 
 ev, ops = steadystate.liouvillianspectrum(H, sqrt(2).*J; rates=0.5.*ones(length(J)), nev = 1)
 @test tracedistance(ρss, ops[1]/tr(ops[1])) < 1e-12
 @test ev[sortperm(abs.(ev))] == ev
+@test isconcretetype(eltype(ops))
 
 # Test iterative solvers
 ρss, h = steadystate.iterative(Hdense, Jdense; log=true)


### PR DESCRIPTION
## Summary

- construct Liouvillian eigenoperators with a concretely typed comprehension instead of `DenseOpType[]`
- refine the Arpack eigenvector matrix type after `eigs`
- add dense and sparse inference regressions for `steadystate.eigenvector` and concrete spectrum operator containers

## SnoopCompile results

The investigation used fresh-process `@snoop_inference`, trigger analysis, and parcel attribution with QuantumOpticsBase master `a888b5a47b4dda3c16971d4f487057b39b9be575`.

- dense steady-state pure inference: 40.8 ms to 10.8 ms; QuantumOptics-owned dynamic triggers removed
- sparse steady-state pure inference: 68.5 ms to 52.9 ms; QuantumOptics-owned dynamic triggers removed
- reportable cold-start comparison (5 cache builds, 4 samples per build): steady-state first task 1344.26 ms to 1320.88 ms and total latency 2994.66 ms to 2969.07 ms

The cold-start reduction is consistent but below the harness materiality threshold. Schrödinger, master, MCWF, and correlation traces were dominated by SciML or other dependency frames, so this PR does not add source changes or manual precompile directives for them.

MCWF first-call samples have a process-level approximately 134/342 ms bimodality in both revisions because GC can fall inside or outside Julia compiler timing. The reportable run showed no MCWF regression: first task changed by -1.10 ms and total latency by -7.09 ms.

Dense `liouvillianspectrum` still has a small real-or-complex union for its eigenvalue vector. Its operator vector and the downstream `eigenvector` result are concrete.

## Tests

- focused steady-state suite: 662 passed
- full package suite: 2645 passed, 1 existing broken
- JET package test: 1 passed
- `git diff --check upstream/master...HEAD`

All local package, SnoopCompile, JET, and cold-start evaluations used the QuantumOpticsBase master commit above.