### PR TITLE
Remove closure boxes from QuantumOptics methods

### DIFF
--- a/src/bloch_redfield_master.jl
+++ b/src/bloch_redfield_master.jl
@@ -62,36 +62,40 @@ function bloch_redfield_tensor(H::AbstractOperator, a_ops; J=SparseOpType[], use
     end
 
     #Calculate secular cutoff scale if needed
-    if use_secular
+    w_cutoff = if use_secular
         dw_min = minimum(abs.(W[W .!= 0.0]))
-        w_cutoff = dw_min * secular_cutoff
+        dw_min * secular_cutoff
+    else
+        nothing
     end
 
     #Initialize R_abcd array
     data = zeros(ComplexF64, N, N, N, N)
     #Loop through all indices and calculate elements - seems to be as efficient as any fancy broadcasting implementation (and much simpler to read)
-    Threads.@threads for idx in CartesianIndices(data)
+    let data = data, w_cutoff = w_cutoff
+        Threads.@threads for idx in CartesianIndices(data)
 
-        a, b, c, d = Tuple(idx) #Unpack indices
+            a, b, c, d = Tuple(idx) #Unpack indices
 
-        #Skip any values that are larger than the secular cutoff
-        if use_secular && abs(W[a, b] - W[c, d]) > w_cutoff
-            continue
+            #Skip any values that are larger than the secular cutoff
+            if use_secular && abs(W[a, b] - W[c, d]) > w_cutoff
+                continue
+            end
+
+            """ Term 1 """
+            sum!(view(data, idx), @views A[a, c, :] .* A[d, b, :] .* (Jw[c, a, :] .+ Jw[d, b, :]) ) #Broadcasting over interaction operators
+
+            """ Term 2 (b == d) """
+            if b == d
+                data[idx] -= @views sum( A[a, :, :] .* A[:, c, :] .* Jw[c, :, :] ) #Broadcasting over interaction operators and extra sum over n
+            end
+
+            """ Term 3 (a == c) """
+            if a == c
+                data[idx] -= @views sum( A[d, :, :] .* A[:, b, :] .* Jw[d, :, :] ) #Broadcasting over interaction operators and extra sum over n
+            end
+
         end
-
-        """ Term 1 """
-        sum!(view(data, idx), @views A[a, c, :] .* A[d, b, :] .* (Jw[c, a, :] .+ Jw[d, b, :]) ) #Broadcasting over interaction operators
-
-        """ Term 2 (b == d) """
-        if b == d
-            data[idx] -= @views sum( A[a, :, :] .* A[:, c, :] .* Jw[c, :, :] ) #Broadcasting over interaction operators and extra sum over n
-        end
-
-        """ Term 3 (a == c) """
-        if a == c
-            data[idx] -= @views sum( A[d, :, :] .* A[:, b, :] .* Jw[d, :, :] ) #Broadcasting over interaction operators and extra sum over n
-        end
-
     end
 
     data *= 0.5 #Don't forget the factor of 1/2

--- a/src/master.jl
+++ b/src/master.jl
@@ -92,13 +92,17 @@ function master(tspan, rho0::Operator, H::AbstractOperator, J;
     isreducible = check_master(rho0, H, J, Jdagger, rates)
     if !isreducible
         tmp = copy(rho0)
-        dmaster_h_(t, rho, drho) = dmaster_h!(drho, H, J, Jdagger, rates, rho, tmp)
+        dmaster_h_ = let tmp = tmp
+            dmaster_h_(t, rho, drho) = dmaster_h!(drho, H, J, Jdagger, rates, rho, tmp)
+        end
         return integrate_master(tspan, dmaster_h_, rho0, fout; kwargs...)
     else
         Hnh = nh_hamiltonian(H,J,Jdagger,rates)
         Hnhdagger = dagger(Hnh)
         tmp = copy(rho0)
-        dmaster_nh_(t, rho, drho) = dmaster_nh!(drho, Hnh, Hnhdagger, J, Jdagger, rates, rho, tmp)
+        dmaster_nh_ = let tmp = tmp
+            dmaster_nh_(t, rho, drho) = dmaster_nh!(drho, Hnh, Hnhdagger, J, Jdagger, rates, rho, tmp)
+        end
         return integrate_master(tspan, dmaster_nh_, rho0, fout; kwargs...)
     end
 end

--- a/src/spectralanalysis.jl
+++ b/src/spectralanalysis.jl
@@ -132,12 +132,16 @@ function eigenstates(op::Operator, ds::LapackDiag; warning=true)
     b = basis(op)
     if ishermitian(op)
         D, V = eigen(Hermitian(op.data), 1:ds.n)
-        states = [Ket(b, V[:, k]) for k=1:length(D)]
+        states = let V = V
+            [Ket(b, V[:, k]) for k=1:length(D)]
+        end
         return D, states
     else
         warning && @warn(nonhermitian_warning)
         D, V = eigen(op.data)
-        states = [Ket(b, V[:, k]) for k=1:length(D)]
+        states = let V = V
+            [Ket(b, V[:, k]) for k=1:length(D)]
+        end
         perm = sortperm(D, by=real)
         permute!(D, perm)
         permute!(states, perm)
@@ -153,7 +157,9 @@ function eigenstates(op::Operator, ds::KrylovDiag; warning::Bool=true, kwargs...
     else
         D, Vs = eigsolve(op.data, ds.v0, ds.n, :SR; krylovdim = ds.krylovdim, kwargs...)
     end
-    states = [Ket(b, Vs[k]) for k=1:ds.n]
+    states = let Vs = Vs
+        [Ket(b, Vs[k]) for k=1:ds.n]
+    end
     D[1:ds.n], states
 end
 

--- a/src/steadystate_iterative.jl
+++ b/src/steadystate_iterative.jl
@@ -110,15 +110,17 @@ function _linmap_liouvillian(rho,H,J,Jdagger,rates)
     end
 
     # Linear mapping
-    function f!(y,x)
-        # Reshape
-        rho.data .= @views reshape(x[1:end-1], M, M)
-        # Apply function
-        dmaster_(drho,rho)
-        # Recast data
-        copyto!(y, 1, drho.data, 1, M^2)
-        y[end] = tr(rho)
-        return y
+    f! = let dmaster_ = dmaster_
+        function f!(y,x)
+            # Reshape
+            rho.data .= @views reshape(x[1:end-1], M, M)
+            # Apply function
+            dmaster_(drho,rho)
+            # Recast data
+            copyto!(y, 1, drho.data, 1, M^2)
+            y[end] = tr(rho)
+            return y
+        end
     end
 
     return LinearMaps.LinearMap{eltype(rho)}(f!,M^2+1;ismutating=true,issymmetric=false,ishermitian=false,isposdef=false)

--- a/src/stochastic_master.jl
+++ b/src/stochastic_master.jl
@@ -66,8 +66,10 @@ function master(tspan, rho0::T, H::AbstractOperator{B,B},
         end
         Hnhdagger = dagger(Hnh)
 
-        dmaster_nh_determ(t, rho, drho) =
-            dmaster_nh!(drho, Hnh, Hnhdagger, J, Jdagger, rates, rho, tmp)
+        dmaster_nh_determ = let Hnh = Hnh
+            dmaster_nh_determ(t, rho, drho) =
+                dmaster_nh!(drho, Hnh, Hnhdagger, J, Jdagger, rates, rho, tmp)
+        end
         integrate_master_stoch(tspan, dmaster_nh_determ, dmaster_stoch, rho0, fout, n; kwargs...)
     end
 end

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -11,5 +11,9 @@ using QuantumOptics
     phasespace_funcs = [:qfunc, :wigner, :coherentspinstate, :qfuncsu2, :wignersu2]
     pirates = [pirate for pirate in Aqua.Piracy.hunt(QuantumOptics) if pirate.name ∉ phasespace_funcs]
     @test isempty(pirates)
+
+    if isdefined(Test, :detect_closure_boxes)
+        @test isempty(getfield(Test, :detect_closure_boxes)(QuantumOptics))
+    end
 end
 end

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -11,9 +11,5 @@ using QuantumOptics
     phasespace_funcs = [:qfunc, :wigner, :coherentspinstate, :qfuncsu2, :wignersu2]
     pirates = [pirate for pirate in Aqua.Piracy.hunt(QuantumOptics) if pirate.name ∉ phasespace_funcs]
     @test isempty(pirates)
-
-    if isdefined(Test, :detect_closure_boxes)
-        @test isempty(getfield(Test, :detect_closure_boxes)(QuantumOptics))
-    end
 end
 end

--- a/test/test_closure_boxes.jl
+++ b/test/test_closure_boxes.jl
@@ -1,0 +1,8 @@
+@testitem "test_closure_boxes" begin
+using Test
+using QuantumOptics
+
+if VERSION >= v"1.14"
+    @test isempty(Test.detect_closure_boxes(QuantumOptics))
+end
+end


### PR DESCRIPTION
## Summary

- isolate final captured values with `let` bindings in the Bloch-Redfield, master-equation, eigenstate, steady-state, and stochastic-master paths
- preserve the threaded array mutation and the non-secular Bloch-Redfield path while removing their `Core.Box` allocations
- add a dedicated `test/test_closure_boxes.jl` regression test, gated with `VERSION >= v"1.14"`

## Closure-box audit

Using Julia `1.14.0-DEV.3007` (`be2a09c9f08`), the upstream baseline reported six methods and eight boxed variables:

- `bloch_redfield_tensor`: `data`, `w_cutoff`
- `timeevolution.master`: `tmp`
- LAPACK `eigenstates`: `V`
- Krylov `eigenstates`: `Vs`
- `steadystate._linmap_liouvillian`: `dmaster_`
- `stochastic.master`: `Hnh`

The same [`Test.detect_closure_boxes`](https://github.com/JuliaLang/julia/blob/67291f9da941fcb0569afb42aaa205ff1973e177/stdlib/Test/src/Test.jl#L2656) audit reports zero methods on this branch.

The dedicated test uses a Julia 1.14 version gate because QuantumOptics supports Julia 1.10.

## Validation

- nightly detector assertion: 0 boxed methods
- affected TestItems on Julia 1.12.6: 149 passed
- full `Pkg.test()` on Julia 1.12.6: 2,645 passed, 1 expected broken
- JET TestItem on Julia 1.12.6: 1 passed
- Aqua TestItem on Julia 1.12.6: 11 passed, 1 expected broken
- affected TestItems and Aqua on Julia 1.10.12: 134 passed, 1 expected broken; the existing steady-state inference assertion error reproduces unchanged on `upstream/master`

No public API or compatibility bound changes are required.
