### PR TITLE
Make time promotion inference-stable

### DIFF
--- a/src/timeevolution_base.jl
+++ b/src/timeevolution_base.jl
@@ -129,7 +129,7 @@ function _promote_time_and_state(u0, H::AbstractOperator, tspan)
     Tt = real(Ts)
     p = Vector{Tt}(undef,0)
     u0_promote = SciMLBase.promote_u0(u0, p, tspan[1])
-    tspan_promote = SciMLBase.promote_tspan(u0_promote.data, p, tspan, nothing, Dict{Symbol, Any}())
+    tspan_promote = SciMLBase.promote_tspan(u0_promote.data, p, tspan, nothing, NamedTuple())
     return tspan_promote, u0_promote
 end
 function _promote_time_and_state(u0, H::AbstractOperator, J, tspan)
@@ -150,7 +150,7 @@ function _promote_time_and_state(u0, H::AbstractOperator, J, tspan)
     Tt = real(Ts)
     p = Vector{Tt}(undef,0)
     u0_promote = SciMLBase.promote_u0(u0, p, tspan[1])
-    tspan_promote = SciMLBase.promote_tspan(u0_promote.data, p, tspan, nothing, Dict{Symbol, Any}())
+    tspan_promote = SciMLBase.promote_tspan(u0_promote.data, p, tspan, nothing, NamedTuple())
     return tspan_promote, u0_promote
 end
 

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -1,0 +1,27 @@
+@testitem "JET optimization regressions" tags = [:jet] begin
+using JET
+using QuantumOptics
+using Test
+
+promoted_span_sum(args...) =
+    sum(first(QuantumOptics.timeevolution._promote_time_and_state(args...)))
+
+@testset "Time and state promotion" begin
+    b = SpinBasis(1//2)
+    psi = spindown(b)
+    rho = dm(psi)
+    H = sigmax(b)
+    J = [sigmam(b)]
+    times = [0.0, 0.1, 0.2]
+
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+        @__MODULE__,
+    ) promoted_span_sum(psi, H, times)
+
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+        @__MODULE__,
+    ) promoted_span_sum(rho, H, J, times)
+end
+end


### PR DESCRIPTION
## Summary

- replace the empty `Dict{Symbol, Any}` passed to `SciMLBase.promote_tspan` with an empty `NamedTuple`
- add flag-gated `JET.@test_opt` regression coverage for Hamiltonian-only and Hamiltonian-plus-jump time promotion
- keep all optimization checks in `test/jet_opt_tests.jl`

## Motivation

JET optimization analysis reported an inferred `Union{Tuple{Any, Any}, Vector{Float64}}` for both `_promote_time_and_state` paths. The untyped empty keyword dictionary was the source. An empty named tuple preserves the existing call semantics while keeping the promoted span concrete.

## Verification

- `JET_TEST=true` focused package run: 3/3 passed on Julia 1.12.6 / JET 0.12.1
- ForwardDiff time-evolution test item: 12/12 passed
- the new assertions fail on the upstream parent and pass with this change

This is the first PR in a three-PR JET optimization stack.