### PR TITLE
Make semiclassical broadcasts inference-stable

### DIFF
--- a/src/semiclassical.jl
+++ b/src/semiclassical.jl
@@ -76,6 +76,9 @@ Broadcast.BroadcastStyle(::StateStyle{B1}, ::StateStyle{B2}) where {B1,B2} = thr
 Broadcast.BroadcastStyle(::StateStyle{B}, ::Broadcast.DefaultArrayStyle{0}) where {B} = StateStyle{B}()
 Broadcast.BroadcastStyle(::Broadcast.DefaultArrayStyle{0}, ::StateStyle{B}) where {B} = StateStyle{B}()
 
+_rebuild_quantum(q::Ket, data) = Ket(q.basis, data)
+_rebuild_quantum(q::Operator, data) = Operator(q.basis_l, q.basis_r, data)
+
 # Out-of-place broadcasting
 @inline function Base.copy(bc::Broadcast.Broadcasted{<:StateStyle{B},Axes,F,Args}) where {B,Axes,F,Args<:Tuple}
     bcf = Broadcast.flatten(bc)
@@ -95,8 +98,7 @@ Broadcast.BroadcastStyle(::Broadcast.DefaultArrayStyle{0}, ::StateStyle{B}) wher
     @inbounds @simd for I in 1:Nc
         data_c[I] = bcf[I+Nq]
     end
-    type = eval(nameof(typeof(qobj)))
-    return State{B}(type(basis(qobj), data_q), data_c)
+    return State{B}(_rebuild_quantum(qobj, data_q), data_c)
 end
 
 for f ∈ [:find_quantum, :find_classical]

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -24,4 +24,21 @@ promoted_span_sum(args...) =
         @__MODULE__,
     ) promoted_span_sum(rho, H, J, times)
 end
+
+@testset "Semiclassical broadcasting" begin
+    b = SpinBasis(1//2)
+    psi = spindown(b)
+    classical = ComplexF64[0.7, 0.2]
+
+    ket_state = semiclassical.State(psi, classical)
+    operator_state = semiclassical.State(dm(psi), classical)
+
+    JET.@test_opt target_modules = (
+        QuantumOptics.semiclassical,
+    ) Base.materialize(Base.broadcasted(*, ket_state, 2.0))
+
+    JET.@test_opt target_modules = (
+        QuantumOptics.semiclassical,
+    ) Base.materialize(Base.broadcasted(*, operator_state, 2.0))
+end
 end


### PR DESCRIPTION
Depends on #545.

This draft is stacked on #545, so its current diff also contains that PR. It will narrow to this commit after the dependency merges.

## Summary

- replace runtime `eval`-based quantum-object reconstruction in semiclassical state broadcasting with typed `Ket` and `Operator` helpers
- add flag-gated `JET.@test_opt` coverage for scalar broadcasting over semiclassical states with both quantum representations
- preserve the existing bases and data while removing compiler barriers from a pervasive broadcast path

## JET findings

On the upstream implementation, each new assertion reports two optimization failures rooted in `Core.eval`. Both paths report zero failures after this change.

## Verification

- focused JET and semiclassical test items: 66/66 passed
- tested on Julia 1.12.6 / JET 0.12.1
- the new assertions fail on the upstream implementation and pass with this change