### PR TITLE
Specialize mixed jump operator callbacks

### DIFF
--- a/src/master.jl
+++ b/src/master.jl
@@ -1,3 +1,20 @@
+function _dmaster_h_function(H, J, Jdagger, rates, tmp)
+    J_ = _tuplify(J)
+    Jdagger_ = _tuplify(Jdagger)
+    return let H = H, J = J_, Jdagger = Jdagger_, rates = rates, tmp = tmp
+        (t, rho, drho) -> dmaster_h!(drho, H, J, Jdagger, rates, rho, tmp)
+    end
+end
+
+function _dmaster_nh_function(Hnh, Hnhdagger, J, Jdagger, rates, tmp)
+    J_ = _tuplify(J)
+    Jdagger_ = _tuplify(Jdagger)
+    return let Hnh = Hnh, Hnhdagger = Hnhdagger, J = J_, Jdagger = Jdagger_,
+            rates = rates, tmp = tmp
+        (t, rho, drho) -> dmaster_nh!(drho, Hnh, Hnhdagger, J, Jdagger, rates, rho, tmp)
+    end
+end
+
 """
     timeevolution.master_h(tspan, rho0, H, J; <keyword arguments>)
 
@@ -16,7 +33,7 @@ function master_h(tspan, rho0::Operator, H::AbstractOperator, J;
     check_master(rho0, H, J, Jdagger, rates)
     tspan, rho0 = _promote_time_and_state(rho0, H, J, tspan)
     tmp = copy(rho0)
-    dmaster_(t, rho, drho) = dmaster_h!(drho, H, J, Jdagger, rates, rho, tmp)
+    dmaster_ = _dmaster_h_function(H, J, Jdagger, rates, tmp)
     integrate_master(tspan, dmaster_, rho0, fout; kwargs...)
 end
 
@@ -44,7 +61,7 @@ function master_nh(tspan, rho0::Operator, Hnh::AbstractOperator, J;
     check_master(rho0, Hnh, J, Jdagger, rates)
     tspan, rho0 = _promote_time_and_state(rho0, Hnh, J, tspan)
     tmp = copy(rho0)
-    dmaster_(t, rho, drho) = dmaster_nh!(drho, Hnh, Hnhdagger, J, Jdagger, rates, rho, tmp)
+    dmaster_ = _dmaster_nh_function(Hnh, Hnhdagger, J, Jdagger, rates, tmp)
     integrate_master(tspan, dmaster_, rho0, fout; kwargs...)
 end
 
@@ -92,17 +109,13 @@ function master(tspan, rho0::Operator, H::AbstractOperator, J;
     isreducible = check_master(rho0, H, J, Jdagger, rates)
     if !isreducible
         tmp = copy(rho0)
-        dmaster_h_ = let tmp = tmp
-            dmaster_h_(t, rho, drho) = dmaster_h!(drho, H, J, Jdagger, rates, rho, tmp)
-        end
+        dmaster_h_ = _dmaster_h_function(H, J, Jdagger, rates, tmp)
         return integrate_master(tspan, dmaster_h_, rho0, fout; kwargs...)
     else
         Hnh = nh_hamiltonian(H,J,Jdagger,rates)
         Hnhdagger = dagger(Hnh)
         tmp = copy(rho0)
-        dmaster_nh_ = let tmp = tmp
-            dmaster_nh_(t, rho, drho) = dmaster_nh!(drho, Hnh, Hnhdagger, J, Jdagger, rates, rho, tmp)
-        end
+        dmaster_nh_ = _dmaster_nh_function(Hnh, Hnhdagger, J, Jdagger, rates, tmp)
         return integrate_master(tspan, dmaster_nh_, rho0, fout; kwargs...)
     end
 end

--- a/src/mcwf.jl
+++ b/src/mcwf.jl
@@ -5,6 +5,21 @@ import ..timeevolution: dschroedinger!
 # TODO: Remove imports
 import RecursiveArrayTools.copyat_or_push!
 
+function _dmcwf_h_function(H, J, Jdagger, rates, tmp)
+    J_ = _tuplify(J)
+    Jdagger_ = _tuplify(Jdagger)
+    return let H = H, J = J_, Jdagger = Jdagger_, rates = rates, tmp = tmp
+        (t, psi, dpsi) -> dmcwf_h!(dpsi, H, J, Jdagger, rates, psi, tmp)
+    end
+end
+
+function _jump_function(J, rates, probs)
+    J_ = _tuplify(J)
+    return let J = J_, rates = rates, probs = probs
+        (rng, t, psi, psi_new) -> jump(rng, t, psi, J, psi_new, probs, rates)
+    end
+end
+
 """
     mcwf_h(tspan, rho0, Hnh, J; <keyword arguments>)
 
@@ -22,13 +37,9 @@ function mcwf_h(tspan, psi0::Ket, H::AbstractOperator, J;
     _check_const.(J)
     _check_const.(Jdagger)
     check_mcwf(psi0, H, J, Jdagger, rates)
-    f = let H = H, J = J, Jdagger = Jdagger, rates = rates, tmp = tmp
-        f(t, psi, dpsi) = dmcwf_h!(dpsi, H, J, Jdagger, rates, psi, tmp)
-    end
+    f = _dmcwf_h_function(H, J, Jdagger, rates, tmp)
     probs = zeros(real(eltype(psi0)), length(J))
-    j = let J = J, probs = probs, rates = rates
-        j(rng, t, psi, psi_new) = jump(rng, t, psi, J, psi_new, probs, rates)
-    end
+    j = _jump_function(J, rates, probs)
     integrate_mcwf(f, j, tspan, psi0, seed, fout;
         display_beforeevent=display_beforeevent,
         display_afterevent=display_afterevent,
@@ -57,9 +68,7 @@ function mcwf_nh(tspan, psi0::Ket, Hnh::AbstractOperator, J;
         f(t, psi, dpsi) = dschroedinger!(dpsi, Hnh, psi)
     end
     probs = zeros(real(eltype(psi0)), length(J))
-    j = let J = J, probs = probs
-        j(rng, t, psi, psi_new) = jump(rng, t, psi, J, psi_new, probs, nothing)
-    end
+    j = _jump_function(J, nothing, probs)
     integrate_mcwf(f, j, tspan, psi0, seed, fout;
         display_beforeevent=display_beforeevent,
         display_afterevent=display_afterevent,
@@ -117,13 +126,9 @@ function mcwf(tspan, psi0::Ket, H::AbstractOperator, J;
     isreducible = check_mcwf(psi0, H, J, Jdagger, rates)
     if !isreducible
         tmp = copy(psi0)
-        dmcwf_h_ = let H = H, J = J, Jdagger = Jdagger, rates = rates, tmp = tmp
-            dmcwf_h_(t, psi, dpsi) = dmcwf_h!(dpsi, H, J, Jdagger, rates, psi, tmp)
-        end
+        dmcwf_h_ = _dmcwf_h_function(H, J, Jdagger, rates, tmp)
         probs = zeros(real(eltype(psi0)), length(J))
-        j_h = let J = J, probs = probs, rates = rates
-            j_h(rng, t, psi, psi_new) = jump(rng, t, psi, J, psi_new, probs, rates)
-        end
+        j_h = _jump_function(J, rates, probs)
         integrate_mcwf(dmcwf_h_, j_h, tspan, psi0, seed,
             fout;
             display_beforeevent=display_beforeevent,
@@ -144,9 +149,7 @@ function mcwf(tspan, psi0::Ket, H::AbstractOperator, J;
             dmcwf_nh_(t, psi, dpsi) = dschroedinger!(dpsi, Hnh, psi)
         end
         probs = zeros(real(eltype(psi0)), length(J))
-        j_nh = let J = J, probs = probs, rates = rates
-            j_nh(rng, t, psi, psi_new) = jump(rng, t, psi, J, psi_new, probs, rates)
-        end
+        j_nh = _jump_function(J, rates, probs)
         integrate_mcwf(dmcwf_nh_, j_nh, tspan, psi0, seed,
             fout;
             display_beforeevent=display_beforeevent,

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -1,6 +1,7 @@
 @testitem "JET optimization regressions" tags = [:jet] begin
 using JET
 using QuantumOptics
+using Random
 using Test
 
 promoted_span_sum(args...) =
@@ -40,5 +41,48 @@ end
     JET.@test_opt target_modules = (
         QuantumOptics.semiclassical,
     ) Base.materialize(Base.broadcasted(*, operator_state, 2.0))
+end
+
+@testset "Mixed jump operator callbacks" begin
+    b = SpinBasis(1//2)
+    psi = spinup(b)
+    rho = dm(psi)
+    H = dense(0.3 * sigmax(b))
+    sparse_jump = sigmam(b)
+    J = [sparse_jump, dense(sparse_jump)]
+    Jdagger = dagger.(J)
+    rates = [0.4, 0.7]
+    Hnh = timeevolution.nh_hamiltonian(H, J, Jdagger, rates)
+    Hnhdagger = dagger(Hnh)
+
+    drho = copy(rho)
+    dmaster_h = timeevolution._dmaster_h_function(H, J, Jdagger, rates, copy(rho))
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) dmaster_h(0.0, rho, drho)
+
+    dmaster_nh = timeevolution._dmaster_nh_function(
+        Hnh, Hnhdagger, J, Jdagger, rates, copy(rho))
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) dmaster_nh(0.0, rho, drho)
+
+    dpsi = copy(psi)
+    dmcwf_h = timeevolution._dmcwf_h_function(H, J, Jdagger, rates, copy(psi))
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) dmcwf_h(0.0, psi, dpsi)
+
+    rng = Xoshiro(1)
+    psi_new = copy(psi)
+    jump_with_rates = timeevolution._jump_function(J, rates, zeros(length(J)))
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) jump_with_rates(rng, 0.0, psi, psi_new)
+
+    jump_without_rates = timeevolution._jump_function(J, nothing, zeros(length(J)))
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) jump_without_rates(rng, 0.0, psi, psi_new)
 end
 end

--- a/test/test_timeevolution_master.jl
+++ b/test/test_timeevolution_master.jl
@@ -142,6 +142,35 @@ tout, ρt = timeevolution.master_nh(T, ρ₀, Hnh, Junscaled; rates=rates_vector
 @test tracedistance(ρt[end], ρ) < 1e-5
 
 
+@testset "Mixed jump operator representations" begin
+    b = SpinBasis(1//2)
+    psi0 = spinup(b)
+    rho0 = dm(psi0)
+    Hmixed = dense(0.3 * sigmax(b))
+    sparse_jump = sigmam(b)
+    mixed_jumps = [sparse_jump, dense(sparse_jump)]
+    dense_jumps = dense.(mixed_jumps)
+    mixed_rates = [0.4, 0.7]
+    mixed_times = [0.0, 2.0]
+    Hmixed_nh = timeevolution.nh_hamiltonian(
+        Hmixed, mixed_jumps, dagger.(mixed_jumps), mixed_rates)
+
+    @test !isconcretetype(eltype(mixed_jumps))
+    for (solver, Hamiltonian) in (
+            (timeevolution.master, Hmixed),
+            (timeevolution.master_h, Hmixed),
+            (timeevolution.master_nh, Hmixed_nh))
+        tout_mixed, rho_mixed = solver(
+            mixed_times, rho0, Hamiltonian, mixed_jumps; rates=mixed_rates)
+        tout_dense, rho_dense = solver(
+            mixed_times, rho0, Hamiltonian, dense_jumps; rates=mixed_rates)
+
+        @test tout_mixed == tout_dense
+        @test maximum(tracedistance.(rho_mixed, rho_dense)) < 1e-12
+    end
+end
+
+
 # Test explicit gamma matrix
 alpha = 0.3
 R = [cos(alpha) -sin(alpha); sin(alpha) cos(alpha)]

--- a/test/test_timeevolution_mcwf.jl
+++ b/test/test_timeevolution_mcwf.jl
@@ -118,6 +118,48 @@ tout, Ψt = timeevolution.mcwf_nh(T, Ψ₀, Hnh, J; seed=UInt(2), reltol=1e-6)
 @test norm(Ψt[end]-Ψ) > 0.1
 
 
+@testset "Mixed jump operator representations" begin
+    b = SpinBasis(1//2)
+    psi0 = spinup(b)
+    Hmixed = dense(0.3 * sigmax(b))
+    sparse_jump = sigmam(b)
+    mixed_jumps = [sparse_jump, dense(sparse_jump)]
+    dense_jumps = dense.(mixed_jumps)
+    mixed_rates = [0.4, 0.7]
+    mixed_times = [0.0, 2.0]
+
+    function test_same_trajectory(mixed_result, dense_result)
+        @test mixed_result[1] == dense_result[1]
+        @test all(norm(mixed_result[2][i] - dense_result[2][i]) < 1e-12
+            for i in eachindex(mixed_result[2]))
+        @test mixed_result[3] ≈ dense_result[3]
+        @test mixed_result[4] == dense_result[4]
+        @test length(mixed_result[3]) == 1
+    end
+
+    for solver in (timeevolution.mcwf, timeevolution.mcwf_h)
+        mixed = solver(mixed_times, psi0, Hmixed, mixed_jumps;
+            rates=mixed_rates, seed=UInt(1), display_jumps=true)
+        dense_result = solver(mixed_times, psi0, Hmixed, dense_jumps;
+            rates=mixed_rates, seed=UInt(1), display_jumps=true)
+        test_same_trajectory(mixed, dense_result)
+    end
+
+    scaled_mixed_jumps = [sqrt(mixed_rates[i]) * mixed_jumps[i]
+        for i in eachindex(mixed_jumps)]
+    scaled_dense_jumps = dense.(scaled_mixed_jumps)
+    Hmixed_nh = timeevolution.nh_hamiltonian(
+        Hmixed, scaled_mixed_jumps, dagger.(scaled_mixed_jumps), nothing)
+    mixed = timeevolution.mcwf_nh(
+        mixed_times, psi0, Hmixed_nh, scaled_mixed_jumps;
+        seed=UInt(1), display_jumps=true)
+    dense_result = timeevolution.mcwf_nh(
+        mixed_times, psi0, Hmixed_nh, scaled_dense_jumps;
+        seed=UInt(1), display_jumps=true)
+    test_same_trajectory(mixed, dense_result)
+end
+
+
 
 # Test convergence to master solution
 tout_master, ρt_master = timeevolution.master(T, ρ₀, H, J)

--- a/test/test_timeevolution_tdops.jl
+++ b/test/test_timeevolution_tdops.jl
@@ -18,6 +18,9 @@ a = destroy(b)
 H0 = number(b)
 Hd = (a + a')
 
+Hvec = [H0, Hd]
+@test timeevolution._tuplify(Hvec) === Hvec
+
 # function and op types homogeneous
 H = TimeDependentSum(cos=>H0, cos=>Hd)
 Htup = timeevolution._tuplify(H)


### PR DESCRIPTION
Depends on #546 (and transitively #545).

This draft is the final PR in the stack, so its current diff contains both dependencies. It will narrow to the mixed-jump commit after they merge.

## Summary

- convert heterogeneous jump-operator vectors to concrete tuples once when static master-equation and MCWF callbacks are constructed
- capture those tuples in explicit closure factories for `master`, `master_h`, `master_nh`, `mcwf`, `mcwf_h`, and `mcwf_nh`
- keep dynamic and stochastic operator paths unchanged
- add mixed sparse/dense integration coverage for all six APIs and flag-gated JET regression tests for the five callback shapes

## JET findings

For a two-operator sparse/dense fixture, direct calls with the abstract vector produced 5, 2, 2, 3, and 3 runtime-dispatch reports across the master, non-Hermitian master, MCWF, rated-jump, and unrated-jump kernels. Every prepared callback now reports zero optimization failures. The closure fields are concrete and contain no `Core.Box`.

## Performance sample

Benchmarks used Julia 1.12.6, one thread, BenchmarkTools 1.8.0, warmed calls, and 10,000 samples.

| Hot callback | Before | After | Allocations |
| --- | ---: | ---: | ---: |
| Hermitian master | 259.7 ns | 176.4 ns | 4 → 0 |
| Hermitian MCWF | 108.8 ns | 67.2 ns | 2 → 0 |
| rated jump | 89.0 ns | 61.7 ns | 3 → 0 |

## Verification

- focused JET/master/MCWF/time-dependent-operator items: 1,432/1,432 passed
- full package suite on the final stack: 2,668 passed, 1 pre-existing broken test
- flag-gated package JET suite: 10/10 on Julia 1.12.6 / JET 0.12.1
- new optimization assertions: 9/9 on Julia 1.10.12 / JET 0.9.18
- independent review found no material issues