### PR TITLE
Add JET coverage for fundamental solver callbacks

### DIFF
--- a/src/bloch_redfield_master.jl
+++ b/src/bloch_redfield_master.jl
@@ -110,6 +110,11 @@ function bloch_redfield_tensor(H::AbstractOperator, a_ops; J=SparseOpType[], use
 
 end #Function
 
+function _dmaster_br_function(L)
+    return let L = L
+        (t, rho, drho) -> dmaster_br(drho, rho, L)
+    end
+end
 
 """
     timeevolution.master_bloch_redfield(tspan, rho0, R, H; <keyword arguments>)
@@ -146,7 +151,7 @@ function master_bloch_redfield(tspan,
     L_ = isa(L, SparseSuperOpType) ? SparseOperator(basis_comp, L.data) : DenseOperator(basis_comp, L.data)
 
     # Derivative function
-    dmaster_br_(t, rho, drho) = dmaster_br(drho, rho, L_)
+    dmaster_br_ = _dmaster_br_function(L_)
 
     return integrate_br(tspan, dmaster_br_, rho0_eb, transf_op, inv_transf_op, fout; kwargs...)
 end

--- a/src/master.jl
+++ b/src/master.jl
@@ -15,6 +15,24 @@ function _dmaster_nh_function(Hnh, Hnhdagger, J, Jdagger, rates, tmp)
     end
 end
 
+function _dmaster_liouville_function(L)
+    return let L = L
+        (t, rho, drho) -> dmaster_liouville!(drho, L, rho)
+    end
+end
+
+function _dmaster_h_dynamic_function(f, rates, tmp)
+    return let f = f, rates = rates, tmp = tmp
+        (t, rho, drho) -> dmaster_h_dynamic!(drho, f, rates, rho, tmp, t)
+    end
+end
+
+function _dmaster_nh_dynamic_function(f, rates, tmp)
+    return let f = f, rates = rates, tmp = tmp
+        (t, rho, drho) -> dmaster_nh_dynamic!(drho, f, rates, rho, tmp, t)
+    end
+end
+
 """
     timeevolution.master_h(tspan, rho0, H, J; <keyword arguments>)
 
@@ -145,7 +163,7 @@ function master(tspan, rho0::Operator, L::SuperOperator; fout=nothing, kwargs...
     rho_ = Ket(b,reshape(rho0.data, dim))
     L_ = Operator(b,b,L.data)
     tspan, rho_ = _promote_time_and_state(rho_, L_, tspan)
-    dmaster_(t,rho,drho) = dmaster_liouville!(drho,L_,rho)
+    dmaster_ = _dmaster_liouville_function(L_)
 
     # Rewrite into density matrix when saving
     tmp = copy(rho0)
@@ -190,7 +208,7 @@ function master_nh_dynamic(tspan, rho0::Operator, f;
                 fout=nothing,
                 kwargs...)
     tmp = copy(rho0)
-    dmaster_(t, rho, drho) = dmaster_nh_dynamic!(drho, f, rates, rho, tmp, t)
+    dmaster_ = _dmaster_nh_dynamic_function(f, rates, tmp)
     integrate_master(tspan, dmaster_, rho0, fout; kwargs...)
 end
 
@@ -236,9 +254,7 @@ function master_dynamic(tspan, rho0::Operator, f;
                 fout=nothing,
                 kwargs...)
     tmp = copy(rho0)
-    dmaster_ = let f = f, tmp = tmp
-        dmaster_(t, rho, drho) = dmaster_h_dynamic!(drho, f, rates, rho, tmp, t)
-    end
+    dmaster_ = _dmaster_h_dynamic_function(f, rates, tmp)
     integrate_master(tspan, dmaster_, rho0, fout; kwargs...)
 end
 

--- a/src/mcwf.jl
+++ b/src/mcwf.jl
@@ -20,6 +20,24 @@ function _jump_function(J, rates, probs)
     end
 end
 
+function _dmcwf_h_dynamic_function(f, rates, tmp)
+    return let f = f, rates = rates, tmp = tmp
+        (t, psi, dpsi) -> dmcwf_h_dynamic!(dpsi, f, rates, psi, tmp, t)
+    end
+end
+
+function _dmcwf_nh_dynamic_function(f)
+    return let f = f
+        (t, psi, dpsi) -> dmcwf_nh_dynamic!(dpsi, f, psi, t)
+    end
+end
+
+function _jump_dynamic_function(f, rates, probs)
+    return let f = f, rates = rates, probs = probs
+        (rng, t, psi, psi_new) -> jump_dynamic(rng, t, psi, f, psi_new, probs, rates)
+    end
+end
+
 """
     mcwf_h(tspan, rho0, Hnh, J; <keyword arguments>)
 
@@ -64,9 +82,7 @@ function mcwf_nh(tspan, psi0::Ket, Hnh::AbstractOperator, J;
     _check_const(Hnh)
     _check_const.(J)
     check_mcwf(psi0, Hnh, J, J, nothing)
-    f = let Hnh = Hnh
-        f(t, psi, dpsi) = dschroedinger!(dpsi, Hnh, psi)
-    end
+    f = _dschroedinger_function(Hnh)
     probs = zeros(real(eltype(psi0)), length(J))
     j = _jump_function(J, nothing, probs)
     integrate_mcwf(f, j, tspan, psi0, seed, fout;
@@ -145,9 +161,7 @@ function mcwf(tspan, psi0::Ket, H::AbstractOperator, J;
                 Hnh -= complex(float(eltype(H)))(0.5im*rates[i])*Jdagger[i]*J[i]
             end
         end
-        dmcwf_nh_ = let Hnh = Hnh  # Hnh type often not inferrable
-            dmcwf_nh_(t, psi, dpsi) = dschroedinger!(dpsi, Hnh, psi)
-        end
+        dmcwf_nh_ = _dschroedinger_function(Hnh)
         probs = zeros(real(eltype(psi0)), length(J))
         j_nh = _jump_function(J, rates, probs)
         integrate_mcwf(dmcwf_nh_, j_nh, tspan, psi0, seed,
@@ -200,14 +214,10 @@ function mcwf_dynamic(tspan, psi0::Ket, f;
     fout=nothing, display_beforeevent=false, display_afterevent=false,
     kwargs...)
     tmp = copy(psi0)
-    dmcwf_ = let f = f, tmp = tmp, rates = rates
-        dmcwf_(t, psi, dpsi) = dmcwf_h_dynamic!(dpsi, f, rates, psi, tmp, t)
-    end
+    dmcwf_ = _dmcwf_h_dynamic_function(f, rates, tmp)
     J = f(first(tspan), psi0)[2]
     probs = zeros(real(eltype(psi0)), length(J))
-    j_ = let f = f, probs = probs, rates = rates
-        j_(rng, t, psi, psi_new) = jump_dynamic(rng, t, psi, f, psi_new, probs, rates)
-    end
+    j_ = _jump_dynamic_function(f, rates, probs)
     integrate_mcwf(dmcwf_, j_, tspan, psi0, seed,
         fout;
         display_beforeevent=display_beforeevent,
@@ -232,14 +242,10 @@ function mcwf_nh_dynamic(tspan, psi0::Ket, f;
     seed=rand(UInt), rates=nothing,
     fout=nothing, display_beforeevent=false, display_afterevent=false,
     kwargs...)
-    dmcwf_ = let f = f
-        dmcwf_(t, psi, dpsi) = dmcwf_nh_dynamic!(dpsi, f, psi, t)
-    end
+    dmcwf_ = _dmcwf_nh_dynamic_function(f)
     J = f(first(tspan), psi0)[2]
     probs = zeros(real(eltype(psi0)), length(J))
-    j_ = let f = f, probs = probs, rates = rates
-        j_(rng, t, psi, psi_new) = jump_dynamic(rng, t, psi, f, psi_new, probs, rates)
-    end
+    j_ = _jump_dynamic_function(f, rates, probs)
     integrate_mcwf(dmcwf_, j_, tspan, psi0, seed,
         fout;
         display_beforeevent=display_beforeevent,
@@ -379,15 +385,7 @@ function integrate_mcwf(dmcwf::T, jumpfun::J, tspan,
     cb = jump_callback(jumpfun, seed, scb, save_before!, save_after!, save_t_index, psi0, rng_state)
     full_cb = SciMLBase.CallbackSet(callback,cb,scb)
 
-    df_ = let state = state, dstate = dstate  # help inference along
-        function df_(dx, x, p, t)
-            recast!(state,x)
-            recast!(dstate,dx)
-            dmcwf(t, state, dstate)
-            recast!(dx,dstate)
-            return nothing
-        end
-    end
+    df_ = _ode_rhs_function(dmcwf, state, dstate)
 
     prob = SciMLBase.ODEProblem{true}(df_, as_vector(psi0), (tspan_[1],tspan_[end]))
 

--- a/src/schroedinger.jl
+++ b/src/schroedinger.jl
@@ -1,3 +1,15 @@
+function _dschroedinger_function(H)
+    return let H = H
+        (t, psi, dpsi) -> dschroedinger!(dpsi, H, psi)
+    end
+end
+
+function _dschroedinger_dynamic_function(f)
+    return let f = f
+        (t, psi, dpsi) -> dschroedinger_dynamic!(dpsi, f, psi, t)
+    end
+end
+
 """
     timeevolution.schroedinger(tspan, psi0, H; fout)
 
@@ -16,7 +28,7 @@ function schroedinger(tspan, psi0::T, H::AbstractOperator;
                 fout=nothing,
                 kwargs...) where {T<:Union{AbstractOperator,StateVector}}
     _check_const(H)
-    dschroedinger_(t, psi, dpsi) = dschroedinger!(dpsi, H, psi)
+    dschroedinger_ = _dschroedinger_function(H)
     tspan, psi0 = _promote_time_and_state(psi0, H, tspan) # promote only if ForwardDiff.Dual
     x0 = psi0.data
     state = copy(psi0)
@@ -46,9 +58,7 @@ Instead of a function `f`, this takes a time-dependent operator `H`.
 function schroedinger_dynamic(tspan, psi0, f;
                 fout=nothing,
                 kwargs...)
-    dschroedinger_ = let f = f
-        dschroedinger_(t, psi, dpsi) = dschroedinger_dynamic!(dpsi, f, psi, t)
-    end
+    dschroedinger_ = _dschroedinger_dynamic_function(f)
     tspan, psi0 = _promote_time_and_state(psi0, f, tspan) # promote only if ForwardDiff.Dual
     x0 = psi0.data
     state = copy(psi0)

--- a/src/semiclassical.jl
+++ b/src/semiclassical.jl
@@ -135,6 +135,35 @@ RecursiveArrayTools.recursivecopy!(dest::State, src::State) = copyto!(dest, src)
 RecursiveArrayTools.recursivecopy(x::State) = copy(x)
 RecursiveArrayTools.recursivefill!(x::State, a) = fill!(x, a)
 
+function _dschroedinger_dynamic_function(fquantum, fclassical!)
+    return let fquantum = fquantum, fclassical! = fclassical!
+        (t, state, dstate) ->
+            dschroedinger_dynamic!(dstate, fquantum, fclassical!, state, t)
+    end
+end
+
+function _dmaster_h_dynamic_function(fquantum, fclassical!, rates, tmp)
+    return let fquantum = fquantum, fclassical! = fclassical!, rates = rates, tmp = tmp
+        (t, state, dstate) ->
+            dmaster_h_dynamic!(dstate, fquantum, fclassical!, rates, state, tmp, t)
+    end
+end
+
+function _dmcwf_h_dynamic_function(fquantum, fclassical!, rates, tmp)
+    return let fquantum = fquantum, fclassical! = fclassical!, rates = rates, tmp = tmp
+        (t, psi, dpsi) ->
+            dmcwf_h_dynamic!(dpsi, fquantum, fclassical!, rates, psi, tmp, t)
+    end
+end
+
+function _jump_dynamic_function(fquantum, fclassical!, fjump_classical!, rates, probs)
+    return let fquantum = fquantum, fclassical! = fclassical!,
+            fjump_classical! = fjump_classical!, rates = rates, probs = probs
+        (rng, t, psi, psi_new) -> jump_dynamic(
+            rng, t, psi, fquantum, fclassical!, fjump_classical!, psi_new, probs, rates)
+    end
+end
+
 """
     semiclassical.schroedinger_dynamic(tspan, state0, fquantum, fclassical[; fout, ...])
 
@@ -157,9 +186,7 @@ Integrate time-dependent Schrödinger equation coupled to a classical system.
 function schroedinger_dynamic(tspan, state0::State, fquantum, fclassical!;
                 fout=nothing,
                 kwargs...)
-    dschroedinger_ = let fquantum = fquantum, fclassical! = fclassical!
-        dschroedinger_(t, state, dstate) = dschroedinger_dynamic!(dstate, fquantum, fclassical!, state, t)
-    end
+    dschroedinger_ = _dschroedinger_dynamic_function(fquantum, fclassical!)
     x0 = Vector{eltype(state0)}(undef, length(state0))
     recast!(x0,state0)
     state = copy(state0)
@@ -191,9 +218,7 @@ function master_dynamic(tspan, state0::State{B,T}, fquantum, fclassical!;
                 fout=nothing,
                 tmp=copy(state0.quantum),
                 kwargs...) where {B,T<:Operator}
-    dmaster_ = let fquantum = fquantum, fclassical! = fclassical!
-        dmaster_(t, state, dstate) = dmaster_h_dynamic!(dstate, fquantum, fclassical!, rates, state, tmp, t)
-    end
+    dmaster_ = _dmaster_h_dynamic_function(fquantum, fclassical!, rates, tmp)
     x0 = Vector{eltype(state0)}(undef, length(state0))
     recast!(x0,state0)
     state = copy(state0)
@@ -242,14 +267,11 @@ function mcwf_dynamic(tspan, psi0::State{B,T}, fquantum, fclassical!, fjump_clas
                 fout=nothing,
                 kwargs...) where {B,T<:Ket}
     tmp=copy(psi0.quantum)
-    dmcwf_ = let fquantum = fquantum, fclassical! = fclassical!
-        dmcwf_(t, psi, dpsi) = dmcwf_h_dynamic!(dpsi, fquantum, fclassical!, rates, psi, tmp, t)
-    end
+    dmcwf_ = _dmcwf_h_dynamic_function(fquantum, fclassical!, rates, tmp)
     J = fquantum(first(tspan), psi0.quantum, psi0.classical)[2]
     probs = zeros(real(eltype(psi0)), length(J))
-    j_ = let fquantum = fquantum, fclassical! = fclassical!, fjump_classical! = fjump_classical!, probs = probs
-        j_(rng, t, psi, psi_new) = jump_dynamic(rng, t, psi, fquantum, fclassical!, fjump_classical!, psi_new, probs, rates)
-    end
+    j_ = _jump_dynamic_function(
+        fquantum, fclassical!, fjump_classical!, rates, probs)
     x0 = Vector{eltype(psi0)}(undef, length(psi0))
     recast!(x0,psi0)
     psi = copy(psi0)

--- a/src/steadystate_iterative.jl
+++ b/src/steadystate_iterative.jl
@@ -1,4 +1,5 @@
-using ..timeevolution: nh_hamiltonian, dmaster_h!, dmaster_nh!, check_master
+using ..timeevolution: nh_hamiltonian, _dmaster_h_function,
+    _dmaster_nh_function, check_master
 
 """
     iterative!(rho0, H, J, [method!], args...; [log=false], kwargs...) -> rho[, log]
@@ -104,9 +105,10 @@ function _linmap_liouvillian(rho,H,J,Jdagger,rates)
     if isreducible
         Hnh = nh_hamiltonian(H,J,Jdagger,rates)
         Hnhdagger = dagger(Hnh)
-        dmaster_ = (drho,rho) -> dmaster_nh!(drho,Hnh,Hnhdagger,J,Jdagger,rates,rho,Jrho_cache)
+        dmaster_ = _dmaster_nh_function(
+            Hnh,Hnhdagger,J,Jdagger,rates,Jrho_cache)
     else
-        dmaster_ = (drho,rho) -> dmaster_h!(drho,H,J,Jdagger,rates,rho,Jrho_cache)
+        dmaster_ = _dmaster_h_function(H,J,Jdagger,rates,Jrho_cache)
     end
 
     # Linear mapping
@@ -115,7 +117,7 @@ function _linmap_liouvillian(rho,H,J,Jdagger,rates)
             # Reshape
             rho.data .= @views reshape(x[1:end-1], M, M)
             # Apply function
-            dmaster_(drho,rho)
+            dmaster_(nothing,rho,drho)
             # Recast data
             copyto!(y, 1, drho.data, 1, M^2)
             y[end] = tr(rho)

--- a/src/stochastic_base.jl
+++ b/src/stochastic_base.jl
@@ -1,9 +1,18 @@
 using QuantumOpticsBase
 using QuantumOpticsBase: check_samebases, check_multiplicable
 using Random: AbstractRNG, randn!
-import ..timeevolution: recast!, QO_CHECKS, pure_inference, as_vector
+import ..timeevolution: recast!, QO_CHECKS, pure_inference, as_vector, _ode_rhs_function
 
 import DiffEqCallbacks, StochasticDiffEq, SciMLBase, DiffEqNoiseProcess
+
+function _sde_noise_function(dg, state, dstate, n)
+    return let dg = dg, state = state, dstate = dstate, n = n
+        function sde_noise(dx, x, p, t)
+            recast!(state, x)
+            dg(dx, t, state, dstate, n)
+        end
+    end
+end
 
 """
     integrate_stoch(tspan, df::Function, dg{Function}, x0{ComplexF64},
@@ -21,17 +30,8 @@ function integrate_stoch(tspan, df, dg, x0,
             ncb=nothing,
             kwargs...)
 
-    function df_(dx, x, p, t)
-        recast!(state,x)
-        recast!(dstate,dx)
-        df(t, state, dstate)
-        recast!(dx,dstate)
-    end
-
-    function dg_(dx, x, p, t)
-        recast!(state,x)
-        dg(dx, t, state, dstate, n)
-    end
+    df_ = _ode_rhs_function(df, state, dstate)
+    dg_ = _sde_noise_function(dg, state, dstate, n)
 
     function fout_(x, t, integrator)
         recast!(state,x)

--- a/src/stochastic_master.jl
+++ b/src/stochastic_master.jl
@@ -1,4 +1,17 @@
-import ...timeevolution: dmaster_h!, dmaster_nh!, dmaster_h_dynamic!, check_master
+import ...timeevolution: dmaster_h!, dmaster_nh!, dmaster_h_dynamic!, check_master,
+    _dmaster_h_function, _dmaster_nh_function, _dmaster_h_dynamic_function
+
+function _dmaster_stochastic_function(C, Cdagger)
+    return let C = C, Cdagger = Cdagger
+        (dx, t, rho, drho, n) -> dmaster_stochastic(dx, rho, C, Cdagger, drho, n)
+    end
+end
+
+function _dmaster_stochastic_dynamic_function(f)
+    return let f = f
+        (dx, t, rho, drho, n) -> dmaster_stoch_dynamic(dx, t, rho, f, drho, n)
+    end
+end
 
 """
     stochastic.master(tspan, rho0, H, J, C; <keyword arguments>)
@@ -42,12 +55,11 @@ function master(tspan, rho0::T, H::AbstractOperator{B,B},
 
     n = length(C)
 
-    dmaster_stoch(dx, t, rho, drho, n) = dmaster_stochastic(dx, rho, C, Cdagger, drho, n)
+    dmaster_stoch = _dmaster_stochastic_function(C, Cdagger)
 
     isreducible = check_master(rho0, H, J, Jdagger, rates) && check_master_stoch(rho0, C, Cdagger)
     if !isreducible
-        dmaster_h_determ(t, rho, drho) =
-            dmaster_h!(drho, H, J, Jdagger, rates, rho, tmp)
+        dmaster_h_determ = _dmaster_h_function(H, J, Jdagger, rates, tmp)
         integrate_master_stoch(tspan, dmaster_h_determ, dmaster_stoch, rho0, fout, n; kwargs...)
     else
         Hnh = copy(H)
@@ -66,10 +78,8 @@ function master(tspan, rho0::T, H::AbstractOperator{B,B},
         end
         Hnhdagger = dagger(Hnh)
 
-        dmaster_nh_determ = let Hnh = Hnh
-            dmaster_nh_determ(t, rho, drho) =
-                dmaster_nh!(drho, Hnh, Hnhdagger, J, Jdagger, rates, rho, tmp)
-        end
+        dmaster_nh_determ = _dmaster_nh_function(
+            Hnh, Hnhdagger, J, Jdagger, rates, tmp)
         integrate_master_stoch(tspan, dmaster_nh_determ, dmaster_stoch, rho0, fout, n; kwargs...)
     end
 end
@@ -119,8 +129,8 @@ function master_dynamic(tspan, rho0::T, fdeterm, fstoch;
         n = noise_processes
     end
 
-    dmaster_determ(t, rho, drho) = dmaster_h_dynamic!(drho, fdeterm, rates, rho, tmp, t)
-    dmaster_stoch(dx, t, rho, drho, n) = dmaster_stoch_dynamic(dx, t, rho, fstoch, drho, n)
+    dmaster_determ = _dmaster_h_dynamic_function(fdeterm, rates, tmp)
+    dmaster_stoch = _dmaster_stochastic_dynamic_function(fstoch)
     integrate_master_stoch(tspan, dmaster_determ, dmaster_stoch, rho0, fout, n; kwargs...)
 end
 master_dynamic(tspan, psi0::Ket, args...; kwargs...) = master_dynamic(tspan, dm(psi0), args...; kwargs...)

--- a/src/stochastic_schroedinger.jl
+++ b/src/stochastic_schroedinger.jl
@@ -1,4 +1,17 @@
-import ...timeevolution: dschroedinger!, dschroedinger_dynamic!, check_schroedinger
+import ...timeevolution: dschroedinger!, dschroedinger_dynamic!, check_schroedinger,
+    _dschroedinger_function, _dschroedinger_dynamic_function
+
+function _dschroedinger_stochastic_function(Hs)
+    return let Hs = Hs
+        (dx, t, psi, dpsi, n) -> dschroedinger_stochastic(dx, psi, Hs, dpsi, n)
+    end
+end
+
+function _dschroedinger_stochastic_dynamic_function(f)
+    return let f = f
+        (dx, t, psi, dpsi, n) -> dschroedinger_stochastic(dx, t, psi, f, dpsi, n)
+    end
+end
 
 """
     stochastic.schroedinger(tspan, state0, H, Hs[; fout, ...])
@@ -38,8 +51,8 @@ function schroedinger(tspan, psi0::T, H::AbstractOperator{B,B}, Hs::Vector;
         @assert isa(h, AbstractOperator{B,B})
     end
 
-    dschroedinger_determ(t, psi, dpsi) = dschroedinger!(dpsi, H, psi)
-    dschroedinger_stoch(dx, t, psi, dpsi, n) = dschroedinger_stochastic(dx, psi, Hs, dpsi, n)
+    dschroedinger_determ = _dschroedinger_function(H)
+    dschroedinger_stoch = _dschroedinger_stochastic_function(Hs)
 
     if normalize_state
         norm_func(u, t, integrator) = normalize!(u)
@@ -99,8 +112,8 @@ function schroedinger_dynamic(tspan, psi0::Ket, fdeterm, fstoch;
     x0 = psi0.data
     state = copy(psi0)
 
-    dschroedinger_determ(t, psi, dpsi) = dschroedinger_dynamic!(dpsi, fdeterm, psi, t)
-    dschroedinger_stoch(dx, t, psi, dpsi, n) = dschroedinger_stochastic(dx, t, psi, fstoch, dpsi, n)
+    dschroedinger_determ = _dschroedinger_dynamic_function(fdeterm)
+    dschroedinger_stoch = _dschroedinger_stochastic_dynamic_function(fstoch)
 
     if normalize_state
         norm_func(u, t, integrator) = normalize!(u)

--- a/src/stochastic_semiclassical.jl
+++ b/src/stochastic_semiclassical.jl
@@ -1,6 +1,21 @@
 using ...semiclassical
 import ...semiclassical: State
 
+function _dschroedinger_semiclassical_stochastic_function(
+        fstoch_quantum, fstoch_classical)
+    return let fstoch_quantum = fstoch_quantum, fstoch_classical = fstoch_classical
+        (dx, t, state, dstate, n) -> dschroedinger_stochastic(
+            dx, t, state, fstoch_quantum, fstoch_classical, dstate, n)
+    end
+end
+
+function _dmaster_semiclassical_stochastic_function(fstoch_quantum, fstoch_classical)
+    return let fstoch_quantum = fstoch_quantum, fstoch_classical = fstoch_classical
+        (dx, t, state, dstate, n) -> dmaster_stoch_dynamic(
+            dx, t, state, fstoch_quantum, fstoch_classical, dstate, n)
+    end
+end
+
 """
     stochastic.schroedinger_semiclassical(tspan, state0, fquantum, fclassical![; fout, ...])
 Integrate time-dependent Schrödinger equation coupled to a classical system.
@@ -46,8 +61,8 @@ function schroedinger_semiclassical(tspan, state0::S, fquantum,
                 normalize_state::Bool=false,
                 kwargs...) where {B<:Basis,T<:Ket{B},S<:State{B,T}}
     tspan_ = convert(Vector{float(eltype(tspan))}, tspan)
-    dschroedinger_det(t, state, dstate) =
-            semiclassical.dschroedinger_dynamic!(dstate, fquantum, fclassical!, state, t)
+    dschroedinger_det = semiclassical._dschroedinger_dynamic_function(
+        fquantum, fclassical!)
 
     if isa(fstoch_quantum, Nothing) && isa(fstoch_classical, Nothing)
         throw(ArgumentError("No stochastic functions provided!"))
@@ -86,8 +101,8 @@ function schroedinger_semiclassical(tspan, state0::S, fquantum,
         ncb = nothing
     end
 
-    dschroedinger_stoch(dx, t, state, dstate, n) =
-            dschroedinger_stochastic(dx, t, state, fstoch_quantum, fstoch_classical, dstate, n)
+    dschroedinger_stoch = _dschroedinger_semiclassical_stochastic_function(
+        fstoch_quantum, fstoch_classical)
 
     integrate_stoch(tspan_, dschroedinger_det, dschroedinger_stoch, x0, state, dstate, fout, n;
                     noise_prototype_classical = noise_prototype_classical,
@@ -167,11 +182,10 @@ function master_semiclassical(tspan, rho0::S,
         end
     end
 
-    dmaster_determ(t, rho, drho) =
-            semiclassical.dmaster_h_dynamic!(drho, fquantum, fclassical!, rates, rho, tmp, t)
-
-    dmaster_stoch(dx, t, rho, drho, n) =
-        dmaster_stoch_dynamic(dx, t, rho, fstoch_quantum, fstoch_classical, drho, n)
+    dmaster_determ = semiclassical._dmaster_h_dynamic_function(
+        fquantum, fclassical!, rates, tmp)
+    dmaster_stoch = _dmaster_semiclassical_stochastic_function(
+        fstoch_quantum, fstoch_classical)
 
     integrate_master_stoch(tspan, dmaster_determ, dmaster_stoch, rho0, fout, n;
                 noise_prototype_classical=noise_prototype_classical,

--- a/src/timeevolution_base.jl
+++ b/src/timeevolution_base.jl
@@ -5,6 +5,18 @@ import OrdinaryDiffEqLowOrderRK, DiffEqCallbacks, SciMLBase
 
 function recast! end
 
+function _ode_rhs_function(df, state, dstate)
+    return let df = df, state = state, dstate = dstate
+        function ode_rhs(dx, x, p, t)
+            recast!(state, x)
+            recast!(dstate, dx)
+            df(t, state, dstate)
+            recast!(dx, dstate)
+            return nothing
+        end
+    end
+end
+
 """
     integrate(tspan, df::Function, x0::Vector{ComplexF64},
             state::T, dstate::T, fout::Function; kwargs...)
@@ -17,15 +29,7 @@ function integrate(tspan, df, x0,
             steady_state = false, tol = 1e-3, save_everystep = false, saveat=tspan,
             callback = nothing, kwargs...)
 
-    df_ = let df = df
-        function df_(dx, x, p, t)
-            recast!(state,x)
-            recast!(dstate,dx)
-            df(t, state, dstate)
-            recast!(dx,dstate)
-            return nothing
-        end
-    end
+    df_ = _ode_rhs_function(df, state, dstate)
 
     fout_ = let fout = fout, state = state
         function fout_(x, t, integrator)

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -1,7 +1,9 @@
 @testitem "JET optimization regressions" tags = [:jet] begin
 using JET
 using QuantumOptics
+using LinearAlgebra
 using Random
+using SparseArrays
 using Test
 
 promoted_span_sum(args...) =
@@ -84,5 +86,374 @@ end
     JET.@test_opt target_modules = (
         QuantumOptics.timeevolution,
     ) jump_without_rates(rng, 0.0, psi, psi_new)
+end
+
+@testset "Fundamental time-evolution callbacks" begin
+    b = SpinBasis(1//2)
+    psi = spinup(b)
+    rho = dm(psi)
+    H = dense(0.3 * sigmax(b))
+    sparse_jump = sigmam(b)
+    J = (sparse_jump, dense(sparse_jump))
+    Jdagger = dagger.(J)
+    rates = [0.4, 0.7]
+    Hnh = timeevolution.nh_hamiltonian(H, J, Jdagger, rates)
+    Hnhdagger = dagger(Hnh)
+
+    dschroedinger = timeevolution._dschroedinger_function(H)
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) dschroedinger(0.0, psi, copy(psi))
+
+    H_dynamic = TimeDependentSum(cos => H, sin => dense(sigmaz(b)))
+    fschroedinger = timeevolution.schroedinger_dynamic_function(H_dynamic)
+    dschroedinger_dynamic = timeevolution._dschroedinger_dynamic_function(fschroedinger)
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) dschroedinger_dynamic(0.0, psi, copy(psi))
+
+    # The non-Hermitian MCWF solver uses the same prepared callback as
+    # the static Schrödinger solver.
+    dmcwf_nh = timeevolution._dschroedinger_function(Hnh)
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) dmcwf_nh(0.0, psi, copy(psi))
+
+    fmaster = let H = H, J = J, Jdagger = Jdagger
+        (t, state) -> (H, J, Jdagger)
+    end
+    fmaster_nh = let Hnh = Hnh, Hnhdagger = Hnhdagger, J = J, Jdagger = Jdagger
+        (t, state) -> (Hnh, Hnhdagger, J, Jdagger)
+    end
+
+    dmaster_dynamic = timeevolution._dmaster_h_dynamic_function(
+        fmaster, rates, copy(rho))
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) dmaster_dynamic(0.0, rho, copy(rho))
+
+    dmaster_nh_dynamic = timeevolution._dmaster_nh_dynamic_function(
+        fmaster_nh, rates, copy(rho))
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) dmaster_nh_dynamic(0.0, rho, copy(rho))
+
+    L = liouvillian(H, collect(J); rates=rates)
+    vector_basis = GenericBasis(length(rho))
+    rho_vector = Ket(vector_basis, vec(copy(rho.data)))
+    L_vector = Operator(vector_basis, vector_basis, L.data)
+    dmaster_liouville = timeevolution._dmaster_liouville_function(L_vector)
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) dmaster_liouville(0.0, rho_vector, copy(rho_vector))
+
+    dmcwf_dynamic = timeevolution._dmcwf_h_dynamic_function(
+        fmaster, rates, copy(psi))
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) dmcwf_dynamic(0.0, psi, copy(psi))
+
+    fmcwf_nh = let Hnh = Hnh, J = J, Jdagger = Jdagger
+        (t, state) -> (Hnh, J, Jdagger)
+    end
+    dmcwf_nh_dynamic = timeevolution._dmcwf_nh_dynamic_function(fmcwf_nh)
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) dmcwf_nh_dynamic(0.0, psi, copy(psi))
+
+    jump_dynamic = timeevolution._jump_dynamic_function(
+        fmaster, rates, zeros(length(J)))
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) jump_dynamic(Xoshiro(1), 0.0, psi, copy(psi))
+
+    ode_rhs = timeevolution._ode_rhs_function(
+        dschroedinger, copy(psi), copy(psi))
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) ode_rhs(similar(psi.data), copy(psi.data), nothing, 0.0)
+
+    master_ode_rhs = timeevolution._ode_rhs_function(
+        dmaster_dynamic, copy(rho), copy(rho))
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) master_ode_rhs(similar(rho.data), copy(rho.data), nothing, 0.0)
+
+    bloch_redfield_basis = b^2
+    L_bloch_redfield = SparseOperator(bloch_redfield_basis, sparse(L.data))
+    rho_bloch_redfield = Ket(bloch_redfield_basis, vec(copy(rho.data)))
+    dmaster_bloch_redfield = timeevolution._dmaster_br_function(L_bloch_redfield)
+    JET.@test_opt target_modules = (
+        QuantumOptics.timeevolution,
+    ) dmaster_bloch_redfield(
+        0.0, rho_bloch_redfield, copy(rho_bloch_redfield))
+end
+
+@testset "Semiclassical solver callbacks" begin
+    b = SpinBasis(1//2)
+    psi = spinup(b)
+    rho = dm(psi)
+    H = dense(0.3 * sigmax(b))
+    J = (dense(sigmam(b)),)
+    Jdagger = dagger.(J)
+    rates = [0.4]
+    classical = ComplexF64[0.2]
+    ket_state = semiclassical.State(psi, copy(classical))
+    rho_state = semiclassical.State(rho, copy(classical))
+
+    fschroedinger = let H = H
+        (t, state, classical) -> H
+    end
+    fmaster = let H = H, J = J, Jdagger = Jdagger
+        (t, state, classical) -> (H, J, Jdagger)
+    end
+    fclassical! = (dclassical, classical, state, t) ->
+        fill!(dclassical, zero(eltype(dclassical)))
+    fjump_classical! = (classical, state, index, t) -> nothing
+
+    dschroedinger = semiclassical._dschroedinger_dynamic_function(
+        fschroedinger, fclassical!)
+    JET.@test_opt target_modules = (
+        QuantumOptics.semiclassical,
+        QuantumOptics.timeevolution,
+    ) dschroedinger(0.0, ket_state, copy(ket_state))
+
+    dmaster = semiclassical._dmaster_h_dynamic_function(
+        fmaster, fclassical!, rates, copy(rho))
+    JET.@test_opt target_modules = (
+        QuantumOptics.semiclassical,
+        QuantumOptics.timeevolution,
+    ) dmaster(0.0, rho_state, copy(rho_state))
+
+    dmcwf = semiclassical._dmcwf_h_dynamic_function(
+        fmaster, fclassical!, rates, copy(psi))
+    JET.@test_opt target_modules = (
+        QuantumOptics.semiclassical,
+        QuantumOptics.timeevolution,
+    ) dmcwf(0.0, ket_state, copy(ket_state))
+
+    jump = semiclassical._jump_dynamic_function(
+        fmaster, fclassical!, fjump_classical!, rates, zeros(length(J)))
+    JET.@test_opt target_modules = (
+        QuantumOptics.semiclassical,
+        QuantumOptics.timeevolution,
+    ) jump(Xoshiro(1), 0.0, ket_state, copy(ket_state))
+
+    x = zeros(ComplexF64, length(ket_state))
+    semiclassical.recast!(x, ket_state)
+    ode_rhs = timeevolution._ode_rhs_function(
+        dschroedinger, copy(ket_state), copy(ket_state))
+    JET.@test_opt target_modules = (
+        QuantumOptics.semiclassical,
+        QuantumOptics.timeevolution,
+    ) ode_rhs(similar(x), x, nothing, 0.0)
+end
+
+@testset "Stochastic solver callbacks" begin
+    b = SpinBasis(1//2)
+    psi = spinup(b)
+    rho = dm(psi)
+    H = dense(0.3 * sigmax(b))
+    Hs = [0.1 * dense(sigmaz(b))]
+    C = [0.1 * dense(sigmam(b))]
+    Cdagger = dagger.(C)
+    C_multiple = [C[1], 0.2 * H]
+    Cdagger_multiple = dagger.(C_multiple)
+
+    dschroedinger_stochastic = stochastic._dschroedinger_stochastic_function(Hs)
+    JET.@test_opt target_modules = (
+        QuantumOptics.stochastic,
+        QuantumOptics.timeevolution,
+    ) dschroedinger_stochastic(
+        zeros(ComplexF64, length(psi)), 0.0, psi, copy(psi), 1)
+
+    homodyne_operators = [0.2 * dense(sigmam(b)), 0.1 * dense(sigmaz(b))]
+    fdeterm_schroedinger, fstochastic_schroedinger =
+        stochastic.homodyne_carmichael(H, homodyne_operators, [0.2, 0.3])
+    dschroedinger_deterministic_dynamic =
+        timeevolution._dschroedinger_dynamic_function(fdeterm_schroedinger)
+    JET.@test_opt target_modules = (
+        QuantumOptics.stochastic,
+        QuantumOptics.timeevolution,
+    ) dschroedinger_deterministic_dynamic(0.0, psi, copy(psi))
+
+    dschroedinger_stochastic_dynamic =
+        stochastic._dschroedinger_stochastic_dynamic_function(
+            fstochastic_schroedinger)
+    JET.@test_opt target_modules = (
+        QuantumOptics.stochastic,
+        QuantumOptics.timeevolution,
+    ) dschroedinger_stochastic_dynamic(
+        zeros(ComplexF64, length(psi), length(homodyne_operators)),
+        0.0, psi, copy(psi), length(homodyne_operators))
+
+    dmaster_stochastic = stochastic._dmaster_stochastic_function(C, Cdagger)
+    JET.@test_opt target_modules = (
+        QuantumOptics.stochastic,
+        QuantumOptics.timeevolution,
+    ) dmaster_stochastic(
+        zeros(ComplexF64, length(rho)), 0.0, rho, copy(rho), 1)
+
+    fstochastic_master = let C = C_multiple, Cdagger = Cdagger_multiple
+        (t, state) -> (C, Cdagger)
+    end
+    dmaster_stochastic_dynamic = stochastic._dmaster_stochastic_dynamic_function(
+        fstochastic_master)
+    JET.@test_opt target_modules = (
+        QuantumOptics.stochastic,
+        QuantumOptics.timeevolution,
+    ) dmaster_stochastic_dynamic(
+        zeros(ComplexF64, length(rho), length(C_multiple)),
+        0.0, rho, copy(rho), length(C_multiple))
+
+    sde_noise = stochastic._sde_noise_function(
+        dschroedinger_stochastic_dynamic,
+        copy(psi), copy(psi), length(homodyne_operators))
+    JET.@test_opt target_modules = (
+        QuantumOptics.stochastic,
+        QuantumOptics.timeevolution,
+    ) sde_noise(
+        zeros(ComplexF64, length(psi), length(homodyne_operators)),
+        copy(psi.data), nothing, 0.0)
+
+    x = stochastic.as_vector(rho)
+    master_sde_noise = stochastic._sde_noise_function(
+        dmaster_stochastic, copy(rho), copy(rho), 1)
+    JET.@test_opt target_modules = (
+        QuantumOptics.stochastic,
+        QuantumOptics.timeevolution,
+    ) master_sde_noise(similar(x), copy(x), nothing, 0.0)
+end
+
+@testset "Stochastic semiclassical solver callbacks" begin
+    b = SpinBasis(1//2)
+    psi = spinup(b)
+    rho = dm(psi)
+    Hs = [0.1 * dense(sigmaz(b))]
+    C = [0.1 * dense(sigmam(b))]
+    Cdagger = dagger.(C)
+    classical = ComplexF64[0.2]
+    ket_state = semiclassical.State(psi, copy(classical))
+    rho_state = semiclassical.State(rho, copy(classical))
+
+    fstochastic_schroedinger = let Hs = Hs
+        (t, state, classical) -> Hs
+    end
+    fstochastic_master = let C = C, Cdagger = Cdagger
+        (t, state, classical) -> (C, Cdagger)
+    end
+    fstochastic_classical! = (dclassical, classical, state, t) ->
+        fill!(dclassical, one(eltype(dclassical)))
+
+    dschroedinger_quantum =
+        stochastic._dschroedinger_semiclassical_stochastic_function(
+            fstochastic_schroedinger, nothing)
+    JET.@test_opt target_modules = (
+        QuantumOptics.stochastic,
+        QuantumOptics.semiclassical,
+        QuantumOptics.timeevolution,
+    ) dschroedinger_quantum(
+        zeros(ComplexF64, length(ket_state)),
+        0.0, ket_state, copy(ket_state), 1)
+
+    dschroedinger_classical =
+        stochastic._dschroedinger_semiclassical_stochastic_function(
+            nothing, fstochastic_classical!)
+    JET.@test_opt target_modules = (
+        QuantumOptics.stochastic,
+        QuantumOptics.semiclassical,
+        QuantumOptics.timeevolution,
+    ) dschroedinger_classical(
+        zeros(ComplexF64, length(ket_state), 1),
+        0.0, ket_state, copy(ket_state), 0)
+
+    dschroedinger_combined =
+        stochastic._dschroedinger_semiclassical_stochastic_function(
+            fstochastic_schroedinger, fstochastic_classical!)
+    JET.@test_opt target_modules = (
+        QuantumOptics.stochastic,
+        QuantumOptics.semiclassical,
+        QuantumOptics.timeevolution,
+    ) dschroedinger_combined(
+        zeros(ComplexF64, length(ket_state), 3),
+        0.0, ket_state, copy(ket_state), 1)
+
+    dmaster_quantum = stochastic._dmaster_semiclassical_stochastic_function(
+        fstochastic_master, nothing)
+    JET.@test_opt target_modules = (
+        QuantumOptics.stochastic,
+        QuantumOptics.semiclassical,
+        QuantumOptics.timeevolution,
+    ) dmaster_quantum(
+        zeros(ComplexF64, length(rho_state)),
+        0.0, rho_state, copy(rho_state), 1)
+
+    dmaster_classical = stochastic._dmaster_semiclassical_stochastic_function(
+        nothing, fstochastic_classical!)
+    JET.@test_opt target_modules = (
+        QuantumOptics.stochastic,
+        QuantumOptics.semiclassical,
+        QuantumOptics.timeevolution,
+    ) dmaster_classical(
+        zeros(ComplexF64, length(rho_state), 1),
+        0.0, rho_state, copy(rho_state), 0)
+
+    dmaster_combined = stochastic._dmaster_semiclassical_stochastic_function(
+        fstochastic_master, fstochastic_classical!)
+    JET.@test_opt target_modules = (
+        QuantumOptics.stochastic,
+        QuantumOptics.semiclassical,
+        QuantumOptics.timeevolution,
+    ) dmaster_combined(
+        zeros(ComplexF64, length(rho_state), 3),
+        0.0, rho_state, copy(rho_state), 1)
+
+    sde_noise = stochastic._sde_noise_function(
+        dmaster_combined, copy(rho_state), copy(rho_state), 1)
+    x = zeros(ComplexF64, length(rho_state))
+    semiclassical.recast!(x, rho_state)
+    JET.@test_opt target_modules = (
+        QuantumOptics.stochastic,
+        QuantumOptics.semiclassical,
+        QuantumOptics.timeevolution,
+    ) sde_noise(
+        zeros(ComplexF64, length(rho_state), 3),
+        x, nothing, 0.0)
+end
+
+@testset "Steady-state solvers" begin
+    b = SpinBasis(1//2)
+    rho = dm(spinup(b))
+    H = dense(0.3 * sigmax(b))
+    sparse_jump = sigmam(b)
+    dense_jump = dense(sparse_jump)
+
+    L = liouvillian(H, [dense_jump])
+    if VERSION < v"1.12"
+        # Julia 1.10's compatible JET/compiler combination reports dispatches
+        # in the standard-library dense eigenvalue implementation.
+        JET.@test_opt broken = true target_modules = (
+            QuantumOptics.steadystate,
+        ) steadystate.eigenvector(L)
+    else
+        JET.@test_opt target_modules = (
+            QuantumOptics.steadystate,
+        ) steadystate.eigenvector(L)
+    end
+
+    mixed_jumps = [sparse_jump, dense_jump]
+    Jdagger = dagger.(mixed_jumps)
+    rates = [0.4, 0.7]
+    linear_map = steadystate._linmap_liouvillian(
+        copy(rho), H, mixed_jumps, Jdagger, rates)
+    x = [vec(rho.data); zero(eltype(rho))]
+    y = similar(x)
+
+    # The heterogeneous operator vector currently causes runtime dispatch in
+    # the matrix-free iterative Liouvillian.
+    JET.@test_opt broken = true target_modules = (
+        QuantumOptics.steadystate,
+        QuantumOptics.timeevolution,
+    ) LinearAlgebra.mul!(y, linear_map, x)
 end
 end

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -441,9 +441,7 @@ end
     x = [vec(rho.data); zero(eltype(rho))]
     y = similar(x)
 
-    # The heterogeneous operator vector currently causes runtime dispatch in
-    # the matrix-free iterative Liouvillian.
-    JET.@test_opt broken = true target_modules = (
+    JET.@test_opt target_modules = (
         QuantumOptics.steadystate,
         QuantumOptics.timeevolution,
     ) LinearAlgebra.mul!(y, linear_map, x)

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -429,17 +429,9 @@ end
     dense_jump = dense(sparse_jump)
 
     L = liouvillian(H, [dense_jump])
-    if VERSION < v"1.12"
-        # Julia 1.10's compatible JET/compiler combination reports dispatches
-        # in the standard-library dense eigenvalue implementation.
-        JET.@test_opt broken = true target_modules = (
-            QuantumOptics.steadystate,
-        ) steadystate.eigenvector(L)
-    else
-        JET.@test_opt target_modules = (
-            QuantumOptics.steadystate,
-        ) steadystate.eigenvector(L)
-    end
+    JET.@test_opt target_modules = (
+        QuantumOptics.steadystate,
+    ) steadystate.eigenvector(L)
 
     mixed_jumps = [sparse_jump, dense_jump]
     Jdagger = dagger.(mixed_jumps)

--- a/test/test_steadystate.jl
+++ b/test/test_steadystate.jl
@@ -93,6 +93,20 @@ steadystate.iterative!(ρss, H, J)
 ρss = steadystate.iterative(H, sqrt(2) .* J; rates=diagm(0=>[0.5,0.5]))
 @test tracedistance(ρss, ρt[end]) < 1e-3
 
+@testset "Mixed jump operator representations" begin
+    b = SpinBasis(1//2)
+    Hmixed = dense(0.3 * sigmax(b))
+    sparse_jump = sigmam(b)
+    mixed_jumps = [sparse_jump, dense(sparse_jump)]
+    dense_jumps = dense.(mixed_jumps)
+    mixed_rates = [0.4, 0.7]
+
+    rho_mixed = steadystate.iterative(Hmixed, mixed_jumps; rates=mixed_rates)
+    rho_dense = steadystate.iterative(Hmixed, dense_jumps; rates=mixed_rates)
+
+    @test tracedistance(rho_mixed, rho_dense) < 1e-12
+end
+
 # Test different float types
 ρss32 = Operator(basis, basis, Matrix{ComplexF32}(ρ₀.data))
 Hdense32 = Operator(basis, basis, Matrix{ComplexF32}(H.data))


### PR DESCRIPTION
## Summary

- extract private callback factories for the core, Bloch-Redfield, semiclassical, stochastic, and stochastic-semiclassical time-evolution solvers
- extend the dedicated Julia 1.12 JET CI test item to 43 checks across derivative, jump, ODE/SDE adapter, and steady-state hot paths
- reuse the prepared master callbacks in the iterative steady-state LinearMap so mixed sparse/dense jump operators remain inference-stable

The fixtures follow documented usage, including time-dependent operators, homodyne callbacks, mixed sparse/dense jumps, and quantum-only, classical-only, and combined semiclassical noise.

## Testing

- Julia 1.12.6 JET suite: 43 passed
- Julia 1.12.6 full suite: 2669 passed, 1 existing broken
- mixed iterative LinearMap: zero allocations after warmup; reducible and nonreducible outputs match their direct derivatives
- Julia 1.10.12 full suite: 2643 passed, 1 existing broken, and 1 existing inference assertion error; the same error was reproduced on untouched upstream/master
- git diff --check

No changelog entry is included because this changes private helpers and test coverage without changing the public API.