### PR TITLE
Use DocumenterCodeBlocks in the docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,7 @@
 AnythingLLMDocs = "333fe5f5-19c9-4863-8caf-c9193e7dba62"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCodeBlocks = "b6400b83-267f-4b55-9fd8-bffc853bdfd8"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 QuantumInterface = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
 QuantumOptics = "6e0679c1-51ea-5a7c-ac74-d61b76210b0c"
@@ -10,3 +11,4 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 
 [compat]
 Documenter = "1"
+DocumenterCodeBlocks = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,6 +16,7 @@ end
 build_examples()
 
 using Documenter
+using DocumenterCodeBlocks
 using AnythingLLMDocs
 using QuantumInterface
 using QuantumOptics
@@ -102,6 +103,7 @@ makedocs(
     sitename = "QuantumOptics.jl",
     modules = doc_modules,
     pages = pages,
+    plugins = [CodeBlocks()],
     format = Documenter.HTML(
         assets = [
             asset("assets/favicon.png", class = :ico, islocal = true),

--- a/docs/src/quantumsystems/nlevel.md
+++ b/docs/src/quantumsystems/nlevel.md
@@ -37,5 +37,5 @@ With the transition operator, we can create projectors of the form ``|m\rangle\l
 
 ## [Examples](@id nlevel: Examples)
 
-* [Raman Transition of a ``\Lambda``-scheme Atom](@ref)
+* [Raman Transition of a ``\Lambda``-scheme Atom](../examples/raman.md)
 * [Four level system in many-body formalism](@ref)

--- a/docs/src/timeevolution/master.md
+++ b/docs/src/timeevolution/master.md
@@ -62,5 +62,5 @@ If for any reason this behavior is unwanted, e.g. special operators are used tha
 
 * [Pumped cavity](@ref)
 * [Jaynes-Cummings model](@ref)
-* [Raman Transition of a ``\Lambda``-scheme Atom](@ref)
+* [Raman Transition of a ``\Lambda``-scheme Atom](../examples/raman.md)
 * [Four level system in many-body formalism](@ref)


### PR DESCRIPTION
## Summary

- add DocumenterCodeBlocks 1.x to the documentation environment
- enable the `CodeBlocks()` Documenter plugin in the normal `makedocs` pipeline
- replace two unresolved implicit Raman example references with direct page links

The Raman links are a separate prerequisite commit. Documenter 1.19 could not resolve the implicit `@ref` target whose heading contains inline math, and treated both unresolved references as fatal.

PR #550 is now part of the base branch. It fixes the only QuantumOptics-owned docstring warning found by DocumenterCodeBlocks.

## Quality assurance

DocumenterCodeBlocks performs its built-in docstring-quality checks during its post-render step. Because `docs/make.jl` passes `CodeBlocks()` through `makedocs(..., plugins = ...)`, those checks run in every normal documentation build.

A full local documentation build used Julia 1.12.6, Documenter 1.19.0, and DocumenterCodeBlocks 1.5.0. It executed all 22 notebooks, completed Documenter cross-reference checks, rendered the HTML, and ran the DocumenterCodeBlocks checks. No QuantumOptics-owned `CodeBlocks:` warnings remain. The 12 remaining warnings refer to docstrings owned by QuantumInterface, QuantumOpticsBase, or TensorCore.

```sh
JULIA_PKG_SERVER_REGISTRY_PREFERENCE=conservative JULIA_NUM_THREADS=1 julia -tauto --project=docs docs/make.jl
```

`JULIA_NUM_THREADS=1` neutralizes this shared workspace's globally inherited `auto,auto` setting for child IJulia kernels. The parent docs process still uses `-tauto`; no repository or CI thread setting is changed. Without this local override, a child IJulia kernel exited under the inherited `auto,auto` setting in this environment.
