### PR TITLE
Document the semiclassical State constructor

### DIFF
--- a/src/semiclassical.jl
+++ b/src/semiclassical.jl
@@ -21,6 +21,8 @@ using ..timeevolution
 const QuantumState{B} = Union{Ket{B}, Operator{B,B}}
 
 """
+    State(quantum, classical)
+
 Semi-classical state.
 
 It consists of a quantum part, which is either a `Ket` or a `DenseOperator` and


### PR DESCRIPTION
## Summary

- add the standard leading constructor signature to `semiclassical.State`
- preserve the existing description and public behavior
- keep the change independent of #549 and its documentation-builder dependencies

## Scope

The audit lists 13 diagnostics reached by the QuantumOptics.jl site. Twelve belong to QuantumInterface.jl or QuantumOpticsBase.jl source. This fixes the sole diagnostic owned by this repository.

QuantumOptics.jl does not depend on or use DocStringExtensions. Adding a runtime dependency for one literal constructor signature would make this fix less minimal.

## Validation

- `git diff --check`
- Julia 1.12.6 package load and attached-docstring signature check
- focused Documenter 1.19.0 + DocumenterCodeBlocks 1.5.0 build: no `CodeBlocks:` diagnostic for `QuantumOptics.semiclassical.State`
- all 22 documentation notebooks executed successfully
- local-package `makedocs` against the #549 DocumenterCodeBlocks configuration: exit 0; the `State` tooltip renders the new signature and existing brief; the 12 remaining `CodeBlocks:` warnings are all dependency-owned
- independent review: no findings