### PR TITLE
Install uv before the Buildkite documentation setup

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,6 +61,9 @@ steps:
     env:
       MPLBACKEND: Agg
     command: |
+      docs_uv_dir="$(mktemp -d)"
+      curl -LsSf https://astral.sh/uv/0.12.10/install.sh | env UV_UNMANAGED_INSTALL="$${docs_uv_dir}" sh
+      export PATH="$${docs_uv_dir}:$${PATH}"
       docs_python_env="$(mktemp -d)"
       uv venv --python /usr/bin/python3 "$${docs_python_env}"
       uv pip install --python "$${docs_python_env}/bin/python" --requirement docs/requirements.txt


### PR DESCRIPTION
The Buildkite Docs job stops before the Julia build because `uv` is missing from the worker PATH ([build 181](https://buildkite.com/quantumsavory/quantumoptics-dot-jl/builds/181#01a074e6-feef-4a4c-824b-54ccd3f59379), exit 127).

Install uv 0.12.10 with its standalone installer into a temporary directory and add that directory to the job PATH. `UV_UNMANAGED_INSTALL` keeps the worker shell configuration unchanged. The existing Python environment and pinned documentation requirements are preserved.

Validation:
- Parsed the pipeline YAML and checked the extracted shell command with `bash -n`.
- Executed the Python setup with uv excluded from the initial PATH; installation, all documentation requirements, pinned package imports, and `jupyter --version` passed on Python 3.13.5.
- Julia 1.12.7 documentation and examples environments resolve, and PyCall builds. The full documentation build initially reached notebook execution, where PyCall aborted in multithreaded kernels; #554 fixes that separate failure. With both fixes, the complete local build passes: all 22 notebooks execute and convert, and Documenter completes its doctest and HTML stages. Deployment is skipped outside Buildkite.
- `git diff --check` passes.

This changes CI setup only; no changelog entry is required. The package test suite is unchanged and is being checked in the separate CI test fix.
