### PR TITLE
Avoid time boxing in dynamic master callbacks

### DIFF
--- a/src/time_dependent_operators.jl
+++ b/src/time_dependent_operators.jl
@@ -18,6 +18,13 @@ _tuplify(o::AbstractVector{T}) where T = isconcretetype(T) ? o : (o...,)
 _tuplify(o::Tuple) = o
 _tuplify(o::AbstractOperator) = o
 
+_set_times!(ops, t) = foreach(op -> set_time!(op, t), ops)
+function _set_times!(ops::Tuple, t)
+    # map preserves specialization for each operator type without boxing t.
+    map(op -> set_time!(op, t), ops)
+    return nothing
+end
+
 """
     schroedinger_dynamic_function(H::AbstractTimeDependentOperator)
 
@@ -63,9 +70,8 @@ function master_h_dynamic_function(H::AbstractTimeDependentOperator, Js)
 
     return let Hop = Htup, Jops = Js_tup, Jdops = Jdags_tup
         function _tdop_master_wrapper_1(t, _)
-            f = op -> set_time!(op, t)
-            foreach(f, Jops)
-            foreach(f, Jdops)
+            _set_times!(Jops, t)
+            _set_times!(Jdops, t)
             set_time!(Hop, t)
             return Hop, Jops, Jdops
         end
@@ -91,9 +97,8 @@ function master_nh_dynamic_function(Hnh::AbstractTimeDependentOperator, Js)
 
     return let Hop = Hnhtup, Hdop = Htdagup, Jops = Js_tup, Jdops = Jdags_tup
         function _tdop_master_wrapper_2(t, _)
-            f = op -> set_time!(op, t)
-            foreach(f, Jops)
-            foreach(f, Jdops)
+            _set_times!(Jops, t)
+            _set_times!(Jdops, t)
             set_time!(Hop, t)
             set_time!(Hdop, t)
             return Hop, Hdop, Jops, Jdops

--- a/src/time_dependent_operators.jl
+++ b/src/time_dependent_operators.jl
@@ -63,7 +63,7 @@ function master_h_dynamic_function(H::AbstractTimeDependentOperator, Js)
 
     return let Hop = Htup, Jops = Js_tup, Jdops = Jdags_tup
         function _tdop_master_wrapper_1(t, _)
-            f = Base.Fix2(set_time!, t)
+            f = op -> set_time!(op, t)
             foreach(f, Jops)
             foreach(f, Jdops)
             set_time!(Hop, t)
@@ -91,7 +91,7 @@ function master_nh_dynamic_function(Hnh::AbstractTimeDependentOperator, Js)
 
     return let Hop = Hnhtup, Hdop = Htdagup, Jops = Js_tup, Jdops = Jdags_tup
         function _tdop_master_wrapper_2(t, _)
-            f = Base.Fix2(set_time!, t)
+            f = op -> set_time!(op, t)
             foreach(f, Jops)
             foreach(f, Jdops)
             set_time!(Hop, t)

--- a/src/time_dependent_operators.jl
+++ b/src/time_dependent_operators.jl
@@ -18,13 +18,6 @@ _tuplify(o::AbstractVector{T}) where T = isconcretetype(T) ? o : (o...,)
 _tuplify(o::Tuple) = o
 _tuplify(o::AbstractOperator) = o
 
-_set_times!(ops, t) = foreach(op -> set_time!(op, t), ops)
-function _set_times!(ops::Tuple, t)
-    # map preserves specialization for each operator type without boxing t.
-    map(op -> set_time!(op, t), ops)
-    return nothing
-end
-
 """
     schroedinger_dynamic_function(H::AbstractTimeDependentOperator)
 
@@ -70,8 +63,8 @@ function master_h_dynamic_function(H::AbstractTimeDependentOperator, Js)
 
     return let Hop = Htup, Jops = Js_tup, Jdops = Jdags_tup
         function _tdop_master_wrapper_1(t, _)
-            _set_times!(Jops, t)
-            _set_times!(Jdops, t)
+            foreach(op -> set_time!(op, t), Jops)
+            foreach(op -> set_time!(op, t), Jdops)
             set_time!(Hop, t)
             return Hop, Jops, Jdops
         end
@@ -97,8 +90,8 @@ function master_nh_dynamic_function(Hnh::AbstractTimeDependentOperator, Js)
 
     return let Hop = Hnhtup, Hdop = Htdagup, Jops = Js_tup, Jdops = Jdags_tup
         function _tdop_master_wrapper_2(t, _)
-            _set_times!(Jops, t)
-            _set_times!(Jdops, t)
+            foreach(op -> set_time!(op, t), Jops)
+            foreach(op -> set_time!(op, t), Jdops)
             set_time!(Hop, t)
             set_time!(Hdop, t)
             return Hop, Hdop, Jops, Jdops

--- a/test/test_timeevolution_tdops.jl
+++ b/test/test_timeevolution_tdops.jl
@@ -26,14 +26,14 @@ H = TimeDependentSum(cos=>H0, cos=>Hd)
 Htup = timeevolution._tuplify(H)
 @test Htup === H
 test_settime(Htup)
-@test (@allocated(test_settime)) == 0
+@test (@allocated test_settime(Htup)) == 0
 
 # op types not homogeneous
 H = TimeDependentSum(cos=>H0, cos=>dense(Hd), cos=>LazySum(H0), cos=>LazySum(dense(Hd)))
 Htup = timeevolution._tuplify(H)
 @test Htup !== H
 test_settime(Htup)
-@test (@allocated(test_settime)) == 0
+@test (@allocated test_settime(Htup)) == 0
 
 H = TimeDependentSum(1.0=>H0, cos=>Hd)
 


### PR DESCRIPTION
Dynamic master callbacks box the time argument when `Base.Fix2(set_time!, t)` is passed to `foreach` in the failing Julia 1.12 CI configuration. The repeated allocations make both existing master-equation allocation checks fail ([failing CI](https://github.com/qojulia/QuantumOptics.jl/actions/runs/34001223849)). Pass an explicit `op -> set_time!(op, t)` lambda to each `foreach` call so the compiler preserves specialization.

Both callback implementations use the same code for tuples and vectors. Also correct two allocation checks that measured the `test_settime` function object instead of calling it; keep the existing full-solver allocation assertions intact.

Validation:

- Callback probes on Julia 1.10.12 and 1.12.7 allocate zero bytes for 1, 10, and 100 evaluations, covering both master callback variants, tuples with three or six heterogeneous operator types, and homogeneous vectors.
- All 23 focused time-dependent operator tests pass on both Julia 1.10.12 and 1.12.7, including the full-solver allocation assertions. Julia 1.10 uses a freshly resolved test environment.
- JET: all 43 checks pass on Julia 1.12.7.
- Full `Pkg.test()` with coverage and `allow_reresolve=false` passes on Julia 1.12.7: 2,669 passed and one pre-existing broken test. GPU tests were disabled. The full suite was not rerun on Julia 1.10.
- `git diff --check` passes.

The separate downgrade failure is addressed by #551 and the docs failures by #552 and #554. No changelog file or Skip-Changelog label is configured in this repository.
