### PR TITLE
Run documentation and notebook kernels with one Julia thread

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,6 +60,8 @@ steps:
       ANYTHINGLLM_API_KEY: ANYTHINGLLM_API_KEY
     env:
       MPLBACKEND: Agg
+      # PyCall is not thread-safe in the docs build or its notebook kernels.
+      JULIA_NUM_THREADS: "1"
     command: |
       docs_python_env="$(mktemp -d)"
       uv venv --python /usr/bin/python3 "$${docs_python_env}"
@@ -70,7 +72,7 @@ steps:
       export PYCALL_DEBUG_BUILD="yes"
       julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       julia --project=docs -e 'using Pkg; Pkg.instantiate(); Pkg.build("PyCall")'
-      julia -tauto --project=docs docs/make.jl
+      julia --project=docs docs/make.jl
 
   - label: "Downstream Tests - {{matrix.PACKAGE}}"
     plugins:


### PR DESCRIPTION
After the missing-uv setup in #552 is repaired, the Docs job's first notebook aborts while importing `PyPlot`. The notebook kernels inherit `JULIA_NUM_THREADS=auto`; PyCall has an [open multithreading issue](https://github.com/JuliaPy/PyCall.jl/issues/1096).

Set `JULIA_NUM_THREADS=1` for the Docs step so its notebook kernels use one Julia thread. Remove the explicit `-tauto` override from the parent documentation command because the tutorial also executes PyPlot code in that process. Other CI jobs retain their current thread settings.

Validation on Julia 1.12.7 and Python 3.13.5:
- Reproduced `SIGABRT` (kernel exit code -6) importing PyPlot in three fresh Jupyter kernels with two Julia threads.
- The same notebook imports pass in three fresh kernels with one Julia thread.
- The generated first notebook, `atom-dephasing.jl`, also passes as a Julia script.
- The complete documentation build passes with one thread: all 22 notebooks execute and convert, and Documenter completes its doctest and HTML stages. Deployment is skipped outside Buildkite.
- Pipeline YAML parsing, extracted command `bash -n`, and `git diff --check` pass.

This is a separate CI setup fix from #552 and does not change the package API or tests. No changelog entry is required.
