### PR TITLE
Test every supported Julia minor in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,17 @@ jobs:
           - macOS-latest
         arch:
           - default
+        include:
+          # Keep every supported Julia minor covered as the latest release advances.
+          - version: '1.10'
+            os: ubuntu-latest
+            arch: default
+          - version: '1.11'
+            os: ubuntu-latest
+            arch: default
+          - version: '1.12'
+            os: ubuntu-latest
+            arch: default
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3


### PR DESCRIPTION
QuantumOptics declares Julia 1.10 and later, but the main CI workflow only tests the latest release. Add Linux jobs for Julia 1.10, 1.11, and 1.12 while retaining the latest Julia release (currently 1.13) on Linux, Windows, and macOS.

Validation: parsed the workflow YAML and checked the expanded six-job matrix; `git diff --check` and independent review passed. The resulting CI run passes Julia 1.11 and 1.12 on Linux and Julia 1.13 on all three operating systems. The new Julia 1.10 job exposes the existing steady-state inference failure repaired separately in #557.

The local audit completed the default/Aqua, JET, optional slow, and OpenCL-on-CPU suites on Julia 1.10.12, 1.11.9, 1.12.7, and 1.13.0. It also found the separate slow-suite and Julia 1.13 JET issues repaired in #556 and #558. With the two source repairs, the full Julia 1.10 suite passes 2,710 assertions plus the existing Aqua expected failure, and JET passes 43/43 with unchanged dependency versions. The restored slow suite passes 7/7 and OpenCL passes 10/10 on each supported minor.

Merge #557 first so that the new Julia 1.10 job passes. No package behavior changes in this PR.

Additional local Julia 1.13 validation passed against unchanged master: all 22 documentation notebooks and the complete Documenter build; WaveguideQED downstream (201 assertions); QuantumSavory downstream (15,236 assertions across its 64 default test files). CUDA, ROCm, and Metal devices are absent locally; Buildkite's existing AMDGPU job is still waiting for a ROCm runner.
