### PR TITLE
Check steady-state inference only on Julia 1.11 and later

### DIFF
--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -52,6 +52,12 @@ sorted according to the absolute value of the eigenvalues.
 """
 function liouvillianspectrum(L::DenseSuperOpType; nev::Int = min(10, length(L.basis_r[1])*length(L.basis_r[2])), which::Symbol = :LR, kwargs...)
     d, v = eigen(L.data; kwargs...)
+    # Julia 1.10 does not infer the concrete eigenvalue and eigenvector arrays.
+    T = eltype(L.data)
+    if T <: LinearAlgebra.BlasFloat
+        d = d::Union{Vector{real(T)}, Vector{complex(T)}}
+        v = v::Union{Matrix{T}, Matrix{complex(T)}}
+    end
     indices = sortperm(abs.(d))[1:nev]
     ops = _eigenoperators(L, v, indices)
     return d[indices], ops
@@ -67,7 +73,9 @@ function liouvillianspectrum(L::SparseSuperOpType; nev::Int = min(10, length(L.b
             rethrow(err)
         end
     end
-    # Arpack does not infer the eigenvector matrix type.
+    # Arpack can return real or complex eigenvalues for real input.
+    T = typeof(zero(eltype(L.data))/sqrt(one(eltype(L.data))))
+    d = d::Union{Vector{T}, Vector{complex(T)}}
     v = v::Matrix{eltype(d)}
     indices = sortperm(abs.(d))[1:nev]
     ops = _eigenoperators(L, v, indices)

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -52,12 +52,6 @@ sorted according to the absolute value of the eigenvalues.
 """
 function liouvillianspectrum(L::DenseSuperOpType; nev::Int = min(10, length(L.basis_r[1])*length(L.basis_r[2])), which::Symbol = :LR, kwargs...)
     d, v = eigen(L.data; kwargs...)
-    # Julia 1.10 does not infer the concrete eigenvalue and eigenvector arrays.
-    T = eltype(L.data)
-    if T <: LinearAlgebra.BlasFloat
-        d = d::Union{Vector{real(T)}, Vector{complex(T)}}
-        v = v::Union{Matrix{T}, Matrix{complex(T)}}
-    end
     indices = sortperm(abs.(d))[1:nev]
     ops = _eigenoperators(L, v, indices)
     return d[indices], ops
@@ -73,9 +67,7 @@ function liouvillianspectrum(L::SparseSuperOpType; nev::Int = min(10, length(L.b
             rethrow(err)
         end
     end
-    # Arpack can return real or complex eigenvalues for real input.
-    T = typeof(zero(eltype(L.data))/sqrt(one(eltype(L.data))))
-    d = d::Union{Vector{T}, Vector{complex(T)}}
+    # Arpack does not infer the eigenvector matrix type.
     v = v::Matrix{eltype(d)}
     indices = sortperm(abs.(d))[1:nev]
     ops = _eigenoperators(L, v, indices)

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -428,10 +428,12 @@ end
     sparse_jump = sigmam(b)
     dense_jump = dense(sparse_jump)
 
-    L = liouvillian(H, [dense_jump])
-    JET.@test_opt target_modules = (
-        QuantumOptics.steadystate,
-    ) steadystate.eigenvector(L)
+    if VERSION >= v"1.11"
+        L = liouvillian(H, [dense_jump])
+        JET.@test_opt target_modules = (
+            QuantumOptics.steadystate,
+        ) steadystate.eigenvector(L)
+    end
 
     mixed_jumps = [sparse_jump, dense_jump]
     Jdagger = dagger.(mixed_jumps)

--- a/test/test_steadystate.jl
+++ b/test/test_steadystate.jl
@@ -2,6 +2,7 @@
 using Test
 using QuantumOptics
 using LinearAlgebra
+using SparseArrays
 
 @testset "steadystate" begin
 
@@ -78,6 +79,24 @@ ev, ops = steadystate.liouvillianspectrum(H, sqrt(2).*J; rates=0.5.*ones(length(
 @test tracedistance(ρss, ops[1]/tr(ops[1])) < 1e-12
 @test ev[sortperm(abs.(ev))] == ev
 @test isconcretetype(eltype(ops))
+
+@testset "Real and complex eigenspectra" begin
+    b = FockBasis(1)
+    for T in (Float32, Float64, ComplexF32, ComplexF64), coupling in (0, 1), storage in (identity, sparse)
+        data = T[-3 coupling 0 0; 0 -2 coupling 0; 0 0 -1 coupling; 0 0 0 0]
+        L = SuperOperator((b, b), (b, b), storage(data))
+        values, states = steadystate.liouvillianspectrum(L; nev=2)
+        @test values ≈ [0, -1] atol=1e-5
+        @test all(norm(L * state - value * state) < 1e-5 for (value, state) in zip(values, states))
+    end
+    # Hermitian complex input has real eigenvalues; real input can have complex pairs.
+    for data in ([-3 im 0 0; -im -2 0 0; 0 0 -1 0; 0 0 0 0],
+                 [0.0 -1 0 0; 1 0 0 0; 0 0 -2 0; 0 0 0 -3]), storage in (identity, sparse)
+        L = SuperOperator((b, b), (b, b), storage(data))
+        values, states = steadystate.liouvillianspectrum(L; nev=2)
+        @test all(norm(L * state - value * state) < 1e-5 for (value, state) in zip(values, states))
+    end
+end
 
 # Test iterative solvers
 ρss, h = steadystate.iterative(Hdense, Jdense; log=true)

--- a/test/test_steadystate.jl
+++ b/test/test_steadystate.jl
@@ -2,7 +2,6 @@
 using Test
 using QuantumOptics
 using LinearAlgebra
-using SparseArrays
 
 @testset "steadystate" begin
 
@@ -62,11 +61,16 @@ tss, ρss = steadystate.master(Hdense, Jdense; tol=1e-4)
 ρss = steadystate.eigenvector(H, sqrt(2).*J; rates=0.5.*ones(length(J)), tol=1e-8)
 @test tracedistance(ρss, ρt[end]) < 1e-3
 
-ρss = @inferred steadystate.eigenvector(H, sqrt(2).*J; rates=0.5.*ones(length(J)), nev = 1)
+ρss = steadystate.eigenvector(H, sqrt(2).*J; rates=0.5.*ones(length(J)), nev = 1)
 @test tracedistance(ρss, ρt[end]) < 1e-3
 
-ρss = @inferred steadystate.eigenvector(liouvillian(Hdense, Jdense))
+ρss = steadystate.eigenvector(liouvillian(Hdense, Jdense))
 @test tracedistance(ρss, ρt[end]) < 1e-6
+
+if VERSION >= v"1.11"
+    @inferred steadystate.eigenvector(H, sqrt(2).*J; rates=0.5.*ones(length(J)), nev = 1)
+    @inferred steadystate.eigenvector(liouvillian(Hdense, Jdense))
+end
 
 @test_throws TypeError steadystate.eigenvector(H, J; ncv="a")
 
@@ -79,24 +83,6 @@ ev, ops = steadystate.liouvillianspectrum(H, sqrt(2).*J; rates=0.5.*ones(length(
 @test tracedistance(ρss, ops[1]/tr(ops[1])) < 1e-12
 @test ev[sortperm(abs.(ev))] == ev
 @test isconcretetype(eltype(ops))
-
-@testset "Real and complex eigenspectra" begin
-    b = FockBasis(1)
-    for T in (Float32, Float64, ComplexF32, ComplexF64), coupling in (0, 1), storage in (identity, sparse)
-        data = T[-3 coupling 0 0; 0 -2 coupling 0; 0 0 -1 coupling; 0 0 0 0]
-        L = SuperOperator((b, b), (b, b), storage(data))
-        values, states = steadystate.liouvillianspectrum(L; nev=2)
-        @test values ≈ [0, -1] atol=1e-5
-        @test all(norm(L * state - value * state) < 1e-5 for (value, state) in zip(values, states))
-    end
-    # Hermitian complex input has real eigenvalues; real input can have complex pairs.
-    for data in ([-3 im 0 0; -im -2 0 0; 0 0 -1 0; 0 0 0 0],
-                 [0.0 -1 0 0; 1 0 0 0; 0 0 -2 0; 0 0 0 -3]), storage in (identity, sparse)
-        L = SuperOperator((b, b), (b, b), storage(data))
-        values, states = steadystate.liouvillianspectrum(L; nev=2)
-        @test all(norm(L * state - value * state) < 1e-5 for (value, state) in zip(values, states))
-    end
-end
 
 # Test iterative solvers
 ρss, h = steadystate.iterative(Hdense, Jdense; log=true)


### PR DESCRIPTION
Julia 1.10 does not infer the concrete arrays returned by the steady-state eigensolvers. Require the two `@inferred` checks and the related JET optimization check only on Julia 1.11 and later, using `VERSION >= v"1.11"`.

The numerical steady-state checks still run on Julia 1.10. This PR changes only tests; it does not add library workarounds or change the minimum supported Julia version.

Validation:

- Julia 1.10.12: complete steady-state suite (33 assertions) and JET suite (42 assertions) pass.
- Julia 1.11.9: complete steady-state suite (33 assertions) and JET suite (43 assertions) pass, including the guarded inference checks.
- Full Julia 1.10.12 `Pkg.test()` passes: 2,670 assertions plus one existing Aqua expected failure.
- `git diff --check` passes; the final PR diff contains no source changes.

Merge before #555 to allow its new Julia 1.10 CI job to pass. No changelog entry is needed for this test-only change.
