### PR TITLE
Use numeric constructors for phase-space coordinates on Julia 1.13

### DIFF
--- a/src/phasespace.jl
+++ b/src/phasespace.jl
@@ -28,7 +28,7 @@ function qfunc(rho::AbstractOperator{B,B}, xvec::AbstractVector, yvec::AbstractV
     tmp2 = Ket(b)
     result = Matrix{eltype(rho)}(undef, Nx, Ny)
     @inbounds for j=1:Ny, i=1:Nx
-        result[i, j] = _qfunc_operator(rho, complex(xvec[i], yvec[j])/sqrt(2), tmp1, tmp2)
+        result[i, j] = _qfunc_operator(rho, Complex(xvec[i], yvec[j])/sqrt(2), tmp1, tmp2)
     end
     result
 end
@@ -53,7 +53,7 @@ function qfunc(psi::Ket{B}, xvec::AbstractVector, yvec::AbstractVector) where B<
     points = length(xvec)*length(yvec)
     N = length(b)::Int
     N0 = b.offset
-    _conj_alpha = [complex(x, -y)/sqrt(2) for x=xvec, y=yvec]
+    _conj_alpha = [Complex(x, -y)/sqrt(2) for x=xvec, y=yvec]
 
     # Compute overlap <α|ψ> as reversed sum
     q = psi.data[N]/sqrt(b.N) .* _conj_alpha
@@ -84,7 +84,7 @@ function qfunc(psi::Ket{B}, xvec::AbstractVector, yvec::AbstractVector) where B<
 end
 
 function qfunc(state::Union{Ket{B}, AbstractOperator{B,B}}, x, y) where B<:FockBasis
-    qfunc(state, complex(x, y)/sqrt(2))
+    qfunc(state, Complex(x, y)/sqrt(2))
 end
 
 function _qfunc_operator(rho, alpha, tmp1, tmp2)
@@ -109,7 +109,7 @@ function wigner(rho::Operator{B,B}, x, y) where B<:FockBasis
     b = basis(rho)
     N = b.N
     N0 = b.offset
-    _2α = complex(x, y)*sqrt(2)
+    _2α = Complex(x, y)*sqrt(2)
     abs2_2α = abs2(_2α)
     w = complex(0.)
     coefficient = complex(0.)
@@ -126,7 +126,7 @@ function wigner(rho::Operator{B,B}, xvec::AbstractVector, yvec::AbstractVector) 
     b = basis(rho)
     N = b.N
     N0 = b.offset
-    _2α = [complex(x, y)*sqrt(2) for x=xvec, y=yvec]
+    _2α = [Complex(x, y)*sqrt(2) for x=xvec, y=yvec]
     abs2_2α = abs2.(_2α)
     w = zero(_2α)
     b0 = similar(_2α)

--- a/test/test_phasespace.jl
+++ b/test/test_phasespace.jl
@@ -31,6 +31,12 @@ Wrho_coherent = wigner(rho_coherent, X, Y)
 Wpsi_fock = wigner(psi_fock, X, Y)
 Wrho_fock = wigner(rho_fock, X, Y)
 
+# Numeric coordinates also work when their vectors have an abstract element type.
+@test qfunc(psi_coherent, Any[X...], Any[Y...]) ≈ Qpsi_coherent
+@test qfunc(rho_coherent, Any[X...], Any[Y...]) ≈ Qrho_coherent
+@test wigner(psi_coherent, Any[X...], Any[Y...]) ≈ Wpsi_coherent
+@test wigner(rho_coherent, Any[X...], Any[Y...]) ≈ Wrho_coherent
+
 laguerre3(x) = (-x^3+9x^2-18x+6)/6
 
 for (i,x)=enumerate(X), (j,y)=enumerate(Y)


### PR DESCRIPTION
Julia 1.13 adds `complex(::Type{Union{}}, slurp...) = Union{}`. Package-wide JET analysis of the unconstrained phase-space coordinate arguments includes that type-returning method and reports four possible arithmetic errors in `qfunc` and `wigner`.

Use the numeric `Complex(x, y)` constructor for the five coordinate conversions. For real coordinates, `complex(x, y)` already delegates to this constructor, so numerical behavior and promotion remain the same. The public signatures continue to accept numeric coordinates in `Any`-typed vectors. Four integration checks compare those grids with the existing concrete-vector results for ket and density-operator inputs.

Validation on Julia 1.13.0 with JET 0.12.1:
- Before the change, package-wide JET reports four phase-space errors; all 42 targeted optimization checks pass.
- After the change, all 279 phase-space assertions pass, including the four new abstract-vector cases. Package-wide JET and all 42 optimization checks pass: 322/322 total assertions.
- The test environment preserves all resolved dependency versions and changes only the local QuantumOptics source path.
- Independent source review and `git diff --check` pass.

The full supported-version audit is tracked in #555. This change is independent of the Julia 1.10 eigenspectrum fix in #557.
