### PR TITLE
ci: follow QuantumSavory Buildkite v1 tags

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ secrets:
 steps:
   - label: "QuantumOptics Tests - {{matrix.LABEL}}"
     plugins:
-      - QuantumSavory/julia#v1.14:
+      - QuantumSavory/julia#v1:
           version: "1"
       - JuliaCI/julia-test#v1:
       - JuliaCI/julia-coverage#v1: ~
@@ -53,7 +53,7 @@ steps:
   - label: "Docs"
     branches: "!dependabot/*"
     plugins:
-      - QuantumSavory/julia#v1.14:
+      - QuantumSavory/julia#v1:
           version: "1"
     secrets:
       DOCUMENTER_KEY: DOCUMENTER_KEY_QuantumOptics
@@ -76,7 +76,7 @@ steps:
 
   - label: "Downstream Tests - {{matrix.PACKAGE}}"
     plugins:
-      - QuantumSavory/julia#v1.14:
+      - QuantumSavory/julia#v1:
           version: "1"
     command:
       - echo "Julia depot path $${JULIA_DEPOT_PATH}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ secrets:
 steps:
   - label: "QuantumOptics Tests - {{matrix.LABEL}}"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1.14:
           version: "1"
       - JuliaCI/julia-test#v1:
       - JuliaCI/julia-coverage#v1: ~
@@ -53,7 +53,7 @@ steps:
   - label: "Docs"
     branches: "!dependabot/*"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1.14:
           version: "1"
     secrets:
       DOCUMENTER_KEY: DOCUMENTER_KEY_QuantumOptics
@@ -76,7 +76,7 @@ steps:
 
   - label: "Downstream Tests - {{matrix.PACKAGE}}"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1.14:
           version: "1"
     command:
       - echo "Julia depot path $${JULIA_DEPOT_PATH}"


### PR DESCRIPTION
Use `QuantumSavory/julia#v1` for every external Julia setup step in Buildkite. The pipelines follow the QuantumSavory forks’ maintained major-version tags as new 1.x fixes are published.

Julia runtime selectors, plugin options, commands, and job definitions are unchanged.

Validation: parsed all Buildkite YAML files, verified semantic equality after normalizing only the plugin reference keys, reviewed the exact tag substitutions, and ran `git diff --check`. Verified that both QuantumSavory `v1` tags currently point to the latest tagged fixes. Julia/package/application suites and full hosted Buildkite execution were not run locally because only plugin references changed.
